### PR TITLE
[auth] 세션 기반 관리자 인증 구현

### DIFF
--- a/_backoffice/backend/build.gradle.kts
+++ b/_backoffice/backend/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.test {

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.backoffice.sosangongin.auth.controller;
+
+import com.backoffice.sosangongin.auth.dto.LoginRequest;
+import com.backoffice.sosangongin.auth.dto.LoginResponse;
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.auth.usecase.LoginUseCase;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final LoginUseCase loginUseCase;
+    private final SessionManager sessionManager;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request,
+                                               HttpSession session) {
+        LoginResponse response = loginUseCase.execute(request);
+        String role = response.isRoot() ? SessionManager.ROLE_ROOT : SessionManager.ROLE_BACKOFFICE_USER;
+        sessionManager.setAccountId(session, response.getId());
+        sessionManager.setRole(session, role);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpSession session) {
+        sessionManager.invalidate(session);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
@@ -4,7 +4,6 @@ import com.backoffice.sosangongin.auth.dto.LoginRequest;
 import com.backoffice.sosangongin.auth.dto.LoginResponse;
 import com.backoffice.sosangongin.auth.session.SessionManager;
 import com.backoffice.sosangongin.auth.usecase.LoginUseCase;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,18 +17,16 @@ public class AuthController {
     private final SessionManager sessionManager;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request,
-                                               HttpSession session) {
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = loginUseCase.execute(request);
         String role = response.isRoot() ? SessionManager.ROLE_ROOT : SessionManager.ROLE_BACKOFFICE_USER;
-        sessionManager.setAccountId(session, response.getId());
-        sessionManager.setRole(session, role);
+        sessionManager.afterLogin(response.getId(), role);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpSession session) {
-        sessionManager.invalidate(session);
+    public ResponseEntity<Void> logout() {
+        sessionManager.invalidate();
         return ResponseEntity.ok().build();
     }
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
@@ -1,0 +1,72 @@
+package com.backoffice.sosangongin.auth.domain;
+
+import com.backoffice.sosangongin.global.entity.SoftDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "backoffice_admin")
+public class BackofficeAdmin extends SoftDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "login_id", unique = true, nullable = false)
+    private String loginId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email")
+    private String email;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @Column(name = "is_root", nullable = false)
+    private boolean isRoot = false;
+
+    @Column(name = "is_password_expired", nullable = false)
+    private boolean isPasswordExpired = true;
+
+    // @Column(name = "password_changed_at")
+    // private LocalDateTime passwordChangedAt;
+
+    @Column(name = "failed_login_attempts", nullable = false)
+    private int failedLoginAttempts = 0;
+
+    @Column(name = "is_locked", nullable = false)
+    private boolean isLocked = false;
+
+    @Column(name = "locked_at")
+    private LocalDateTime lockedAt;
+
+    public void increaseFailedAttempts() {
+        this.failedLoginAttempts++;
+    }
+
+    public void lock() {
+        this.isLocked = true;
+        this.lockedAt = LocalDateTime.now();
+    }
+
+    public void resetFailedAttempts() {
+        this.failedLoginAttempts = 0;
+    }
+
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/dto/LoginRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+    private String loginId;
+    private String password;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/dto/LoginResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/dto/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.backoffice.sosangongin.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private UUID id;
+    private String name;
+    private boolean isRoot;
+    private boolean isPasswordExpired;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/init/RootAdminInitializer.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/init/RootAdminInitializer.java
@@ -1,0 +1,31 @@
+package com.backoffice.sosangongin.auth.init;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.auth.repos.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RootAdminInitializer implements ApplicationRunner {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!adminRepository.existsByLoginId("root")) {
+            adminRepository.save(
+                    BackofficeAdmin.builder()
+                            .loginId("root")
+                            .password(passwordEncoder.encode("root"))
+                            .name("root")
+                            .isRoot(true)
+                            .build()
+            );
+        }
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.backoffice.sosangongin.auth.repos;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AdminRepository extends JpaRepository<BackofficeAdmin, UUID> {
+    Optional<BackofficeAdmin> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/service/AuthService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/service/AuthService.java
@@ -1,0 +1,42 @@
+package com.backoffice.sosangongin.auth.service;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.auth.repos.AdminRepository;
+import com.backoffice.sosangongin.global.exception.AccountLockedException;
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private static final int MAX_FAILED_ATTEMPTS = 5;
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public BackofficeAdmin authenticate(String loginId, String password) {
+        BackofficeAdmin admin = adminRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 계정입니다."));
+
+        if (admin.isLocked()) {
+            throw new AccountLockedException("잠긴 계정입니다.");
+        }
+
+        if (!passwordEncoder.matches(password, admin.getPassword())) {
+            admin.increaseFailedAttempts();
+            if (admin.getFailedLoginAttempts() >= MAX_FAILED_ATTEMPTS) {
+                admin.lock();
+            }
+            throw new InvalidCredentialsException("비밀번호가 올바르지 않습니다.");
+        }
+
+        admin.resetFailedAttempts();
+        return admin;
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionAuthenticationFilter.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionAuthenticationFilter.java
@@ -5,7 +5,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,10 +14,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
-@RequiredArgsConstructor
 public class SessionAuthenticationFilter extends OncePerRequestFilter {
-
-    private final SessionManager sessionManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -26,10 +22,12 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
         HttpSession session = request.getSession(false);
 
         if (session != null) {
-            sessionManager.getAccountId(session).ifPresent(accountId -> {
-                String role = sessionManager.getRole(session);
+            Object value = session.getAttribute(SessionManager.ACCOUNT_ID_KEY);
+            if (value instanceof UUID accountId) {
+                Object roleValue = session.getAttribute(SessionManager.ROLE_KEY);
+                String role = roleValue instanceof String r ? r : SessionManager.ROLE_BACKOFFICE_USER;
                 setAuthentication(accountId, role);
-            });
+            }
         }
 
         filterChain.doFilter(request, response);

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionAuthenticationFilter.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.backoffice.sosangongin.auth.session;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class SessionAuthenticationFilter extends OncePerRequestFilter {
+
+    private final SessionManager sessionManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            sessionManager.getAccountId(session).ifPresent(accountId -> {
+                String role = sessionManager.getRole(session);
+                setAuthentication(accountId, role);
+            });
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthentication(UUID accountId, String role) {
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        accountId,
+                        null,
+                        List.of(new SimpleGrantedAuthority(role))
+                );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
@@ -1,0 +1,45 @@
+package com.backoffice.sosangongin.auth.session;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class SessionManager {
+
+    private static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
+    private static final String ROLE_KEY = "ROLE";
+
+    public static final String ROLE_ROOT = "ROLE_ROOT";
+    public static final String ROLE_BACKOFFICE_USER = "ROLE_BACKOFFICE_USER";
+
+    public void setAccountId(HttpSession session, UUID accountId) {
+        session.setAttribute(ACCOUNT_ID_KEY, accountId);
+    }
+
+    public Optional<UUID> getAccountId(HttpSession session) {
+        Object value = session.getAttribute(ACCOUNT_ID_KEY);
+        if (value instanceof UUID accountId) {
+            return Optional.of(accountId);
+        }
+        return Optional.empty();
+    }
+
+    public void setRole(HttpSession session, String role) {
+        session.setAttribute(ROLE_KEY, role);
+    }
+
+    public String getRole(HttpSession session) {
+        Object value = session.getAttribute(ROLE_KEY);
+        if (value instanceof String role) {
+            return role;
+        }
+        return ROLE_BACKOFFICE_USER;
+    }
+
+    public void invalidate(HttpSession session) {
+        session.invalidate();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
@@ -1,25 +1,32 @@
 package com.backoffice.sosangongin.auth.session;
 
 import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @Component
+@RequestScope
+@RequiredArgsConstructor
 public class SessionManager {
 
-    private static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
-    private static final String ROLE_KEY = "ROLE";
+    static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
+    static final String ROLE_KEY = "ROLE";
 
     public static final String ROLE_ROOT = "ROLE_ROOT";
     public static final String ROLE_BACKOFFICE_USER = "ROLE_BACKOFFICE_USER";
 
-    public void setAccountId(HttpSession session, UUID accountId) {
+    private final HttpSession session;
+
+    public void afterLogin(UUID accountId, String role) {
         session.setAttribute(ACCOUNT_ID_KEY, accountId);
+        session.setAttribute(ROLE_KEY, role);
     }
 
-    public Optional<UUID> getAccountId(HttpSession session) {
+    public Optional<UUID> getAccountId() {
         Object value = session.getAttribute(ACCOUNT_ID_KEY);
         if (value instanceof UUID accountId) {
             return Optional.of(accountId);
@@ -27,11 +34,7 @@ public class SessionManager {
         return Optional.empty();
     }
 
-    public void setRole(HttpSession session, String role) {
-        session.setAttribute(ROLE_KEY, role);
-    }
-
-    public String getRole(HttpSession session) {
+    public String getRole() {
         Object value = session.getAttribute(ROLE_KEY);
         if (value instanceof String role) {
             return role;
@@ -39,7 +42,7 @@ public class SessionManager {
         return ROLE_BACKOFFICE_USER;
     }
 
-    public void invalidate(HttpSession session) {
+    public void invalidate() {
         session.invalidate();
     }
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/usecase/LoginUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/usecase/LoginUseCase.java
@@ -1,0 +1,26 @@
+package com.backoffice.sosangongin.auth.usecase;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.auth.dto.LoginRequest;
+import com.backoffice.sosangongin.auth.dto.LoginResponse;
+import com.backoffice.sosangongin.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LoginUseCase {
+
+    private final AuthService authService;
+
+    public LoginResponse execute(LoginRequest request) {
+        BackofficeAdmin admin = authService.authenticate(request.getLoginId(), request.getPassword());
+
+        return LoginResponse.builder()
+                .id(admin.getId())
+                .name(admin.getName())
+                .isRoot(admin.isRoot())
+                .isPasswordExpired(admin.isPasswordExpired())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.backoffice.sosangongin.config;
 
 import com.backoffice.sosangongin.auth.session.SessionAuthenticationFilter;
-import com.backoffice.sosangongin.auth.session.SessionManager;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +19,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
-    private final SessionManager sessionManager;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -41,7 +39,7 @@ public class SecurityConfig {
                         })
                 )
                 .addFilterBefore(
-                        new SessionAuthenticationFilter(sessionManager),
+                        new SessionAuthenticationFilter(),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .authorizeHttpRequests(auth -> auth

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.backoffice.sosangongin.config;
 
+import com.backoffice.sosangongin.auth.session.SessionAuthenticationFilter;
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
@@ -16,6 +20,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
+    private final SessionManager sessionManager;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -30,8 +35,18 @@ public class SecurityConfig {
                 .headers(headers -> headers
                         .frameOptions(frame -> frame.sameOrigin())
                 )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                        })
+                )
+                .addFilterBefore(
+                        new SessionAuthenticationFilter(sessionManager),
+                        UsernamePasswordAuthenticationFilter.class
+                )
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
                 );
 
         return http.build();

--- a/_backoffice/backend/src/main/resources/application-local.yml
+++ b/_backoffice/backend/src/main/resources/application-local.yml
@@ -4,9 +4,9 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-  sql:
-    init:
-      mode: always
+#  sql:
+#    init:
+#      mode: always
   jpa:
     hibernate:
       ddl-auto: create-drop

--- a/_backoffice/backend/src/test/java/com/backoffice/sosangongin/auth/AuthApiTest.java
+++ b/_backoffice/backend/src/test/java/com/backoffice/sosangongin/auth/AuthApiTest.java
@@ -1,0 +1,103 @@
+package com.backoffice.sosangongin.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("로그인 성공 → 200")
+    void login_success() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("root"))
+                .andExpect(jsonPath("$.root").value(true));
+    }
+
+    @Test
+    @DisplayName("로그인 실패 (잘못된 비밀번호) → 401")
+    void login_fail_wrongPassword() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "wrong"));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("미인증 접근 → 401")
+    void unauthenticated_access_returns_401() throws Exception {
+        mockMvc.perform(get("/api/some-protected-resource"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 후 인증 필요 경로 접근 → 401 아님")
+    void authenticated_access_after_login() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession();
+
+        mockMvc.perform(get("/api/some-protected-resource")
+                        .session(session))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("로그아웃 → 200")
+    void logout_success() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession();
+
+        mockMvc.perform(post("/api/auth/logout")
+                        .session(session))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 개요
 - 백오피스 관리자 로그인/로그아웃 및 세션 기반 인증 체계를 구현합니다.

## 작업 내용
 - BackofficeAdmin 엔티티
 - AdminRepository
 - 로그인 API
 - 로그아웃 API
 - SessionManager (세션 저장/조회/만료)
 - SessionAuthenticationFilter (매 요청 인증 처리)
 - SecurityConfig 인증 적용
 - RootAdminInitializer (로컬 root 계정 초기화)

## 주요 결정 사항
### 세션 처리 주체
 - Controller가 HttpSession을 받아 SessionManager에 넘기고,
UseCase/Service는 웹 객체를 모르도록 레이어 책임을 분리했습니다.

### Role 세션 저장
 - 매 요청마다 DB 조회 없이 세션에서 Role을 꺼내 인증하도록 로그인 시점에 Role을 세션에 함께 저장합니다.

### RootAdminInitializer
 - root 계정은 별도 가입 플로우 없이 앱 시작 시 자동 생성합니다.
 - existsByLoginId 체크로 중복 생성을 방지합니다.

## 테스트
 - 로그인 성공 -> 200 및 세션 생성 확인
 - 미인증 접근 -> 401(명시)
 - 로그아웃 -> 200확인