### PR TITLE
[account] 관리자 계정 CRUD 구현

### DIFF
--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
@@ -7,7 +7,6 @@ import com.backoffice.sosangongin.account.dto.PasswordChangeRequest;
 import com.backoffice.sosangongin.account.usecase.AccountUseCase;
 import com.backoffice.sosangongin.auth.session.SessionManager;
 import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -57,9 +56,8 @@ public class AccountController {
     }
 
     @PatchMapping("/me/password")
-    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request,
-                                               HttpSession session) {
-        UUID requesterId = sessionManager.getAccountId(session)
+    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request) {
+        UUID requesterId = sessionManager.getAccountId()
                 .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
         accountUseCase.changePassword(requesterId, request);
         return ResponseEntity.ok().build();

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
@@ -1,0 +1,67 @@
+package com.backoffice.sosangongin.account.controller;
+
+import com.backoffice.sosangongin.account.dto.AccountCreateRequest;
+import com.backoffice.sosangongin.account.dto.AccountResponse;
+import com.backoffice.sosangongin.account.dto.AccountUpdateRequest;
+import com.backoffice.sosangongin.account.dto.PasswordChangeRequest;
+import com.backoffice.sosangongin.account.usecase.AccountUseCase;
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountUseCase accountUseCase;
+    private final SessionManager sessionManager;
+
+    @PostMapping
+    public ResponseEntity<AccountResponse> create(@RequestBody AccountCreateRequest request) {
+        return ResponseEntity.status(201).body(accountUseCase.create(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AccountResponse>> findAll() {
+        return ResponseEntity.ok(accountUseCase.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AccountResponse> findById(@PathVariable UUID id) {
+        return ResponseEntity.ok(accountUseCase.findById(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<AccountResponse> update(@PathVariable UUID id,
+                                                  @RequestBody AccountUpdateRequest request) {
+        return ResponseEntity.ok(accountUseCase.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        accountUseCase.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/unlock")
+    public ResponseEntity<Void> unlock(@PathVariable UUID id) {
+        accountUseCase.unlock(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request,
+                                               HttpSession session) {
+        UUID requesterId = sessionManager.getAccountId(session)
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        accountUseCase.changePassword(requesterId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountCreateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountCreateRequest.java
@@ -1,0 +1,13 @@
+package com.backoffice.sosangongin.account.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccountCreateRequest {
+    private String loginId;
+    private String name;
+    private String email;
+    private String phoneNumber;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountResponse.java
@@ -1,0 +1,36 @@
+package com.backoffice.sosangongin.account.dto;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AccountResponse {
+    private UUID id;
+    private String loginId;
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private boolean isRoot;
+    private boolean isLocked;
+    private boolean isPasswordExpired;
+    private LocalDateTime createdAt;
+
+    public static AccountResponse from(BackofficeAdmin admin) {
+        return AccountResponse.builder()
+                .id(admin.getId())
+                .loginId(admin.getLoginId())
+                .name(admin.getName())
+                .email(admin.getEmail())
+                .phoneNumber(admin.getPhoneNumber())
+                .isRoot(admin.isRoot())
+                .isLocked(admin.isLocked())
+                .isPasswordExpired(admin.isPasswordExpired())
+                .createdAt(admin.getCreatedAt())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountUpdateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.backoffice.sosangongin.account.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccountUpdateRequest {
+    private String name;
+    private String email;
+    private String phoneNumber;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/PasswordChangeRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/PasswordChangeRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.account.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordChangeRequest {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/service/AccountService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/service/AccountService.java
@@ -1,0 +1,90 @@
+package com.backoffice.sosangongin.account.service;
+
+import com.backoffice.sosangongin.account.dto.*;
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.auth.repos.AdminRepository;
+import com.backoffice.sosangongin.global.exception.DuplicateResourceException;
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import com.backoffice.sosangongin.global.exception.PermissionDeniedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public BackofficeAdmin create(AccountCreateRequest request) {
+        if (adminRepository.existsByLoginId(request.getLoginId())) {
+            throw new DuplicateResourceException("이미 존재하는 아이디입니다.");
+        }
+
+        return adminRepository.save(
+                BackofficeAdmin.builder()
+                        .loginId(request.getLoginId())
+                        .password(passwordEncoder.encode(request.getLoginId()))
+                        .name(request.getName())
+                        .email(request.getEmail())
+                        .phoneNumber(request.getPhoneNumber())
+                        .isRoot(false)
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<BackofficeAdmin> findAll() {
+        return adminRepository.findByDeletedAtIsNull();
+    }
+
+    @Transactional(readOnly = true)
+    public BackofficeAdmin findById(UUID id) {
+        return adminRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 계정입니다."));
+    }
+
+    @Transactional
+    public BackofficeAdmin update(UUID id, AccountUpdateRequest request) {
+        BackofficeAdmin admin = findById(id);
+        if (admin.isRoot()) {
+            throw new PermissionDeniedException("root 계정은 수정할 수 없습니다.");
+        }
+        admin.update(request.getName(), request.getEmail(), request.getPhoneNumber());
+        return admin;
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        BackofficeAdmin admin = findById(id);
+        if (admin.isRoot()) {
+            throw new PermissionDeniedException("root 계정은 삭제할 수 없습니다.");
+        }
+        admin.delete();
+    }
+
+    @Transactional
+    public void unlock(UUID id) {
+        BackofficeAdmin admin = findById(id);
+        if (admin.isRoot()) {
+            throw new PermissionDeniedException("root 계정은 잠금 해제 대상이 아닙니다.");
+        }
+        admin.unlock();
+    }
+
+    @Transactional
+    public void changePassword(UUID id, PasswordChangeRequest request) {
+        BackofficeAdmin admin = findById(id);
+        if (!passwordEncoder.matches(request.getCurrentPassword(), admin.getPassword())) {
+            throw new InvalidCredentialsException("현재 비밀번호가 올바르지 않습니다.");
+        }
+        admin.changePassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/usecase/AccountUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/usecase/AccountUseCase.java
@@ -1,0 +1,47 @@
+package com.backoffice.sosangongin.account.usecase;
+
+import com.backoffice.sosangongin.account.dto.*;
+import com.backoffice.sosangongin.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AccountUseCase {
+
+    private final AccountService accountService;
+
+    public AccountResponse create(AccountCreateRequest request) {
+        return AccountResponse.from(accountService.create(request));
+    }
+
+    public List<AccountResponse> findAll() {
+        return accountService.findAll().stream()
+                .map(AccountResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public AccountResponse findById(UUID id) {
+        return AccountResponse.from(accountService.findById(id));
+    }
+
+    public AccountResponse update(UUID id, AccountUpdateRequest request) {
+        return AccountResponse.from(accountService.update(id, request));
+    }
+
+    public void delete(UUID id) {
+        accountService.delete(id);
+    }
+
+    public void unlock(UUID id) {
+        accountService.unlock(id);
+    }
+
+    public void changePassword(UUID requesterId, PasswordChangeRequest request) {
+        accountService.changePassword(requesterId, request);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
@@ -4,7 +4,6 @@ import com.backoffice.sosangongin.auth.dto.LoginRequest;
 import com.backoffice.sosangongin.auth.dto.LoginResponse;
 import com.backoffice.sosangongin.auth.session.SessionManager;
 import com.backoffice.sosangongin.auth.usecase.LoginUseCase;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,18 +17,16 @@ public class AuthController {
     private final SessionManager sessionManager;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request,
-                                               HttpSession session) {
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = loginUseCase.execute(request);
         String role = response.isRoot() ? SessionManager.ROLE_ROOT : SessionManager.ROLE_BACKOFFICE_USER;
-        sessionManager.setAccountId(session, response.getId());
-        sessionManager.setRole(session, role);
+        sessionManager.afterLogin(response.getId(), role);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpSession session) {
-        sessionManager.invalidate(session);
+    public ResponseEntity<Void> logout() {
+        sessionManager.invalidate();
         return ResponseEntity.ok().build();
     }
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
@@ -44,8 +44,8 @@ public class BackofficeAdmin extends SoftDeletedBaseEntity {
     @Column(name = "is_password_expired", nullable = false)
     private boolean isPasswordExpired = true;
 
-    // @Column(name = "password_changed_at")
-    // private LocalDateTime passwordChangedAt;
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
 
     @Column(name = "failed_login_attempts", nullable = false)
     private int failedLoginAttempts = 0;
@@ -67,6 +67,24 @@ public class BackofficeAdmin extends SoftDeletedBaseEntity {
 
     public void resetFailedAttempts() {
         this.failedLoginAttempts = 0;
+    }
+
+    public void update(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void unlock() {
+        this.isLocked = false;
+        this.lockedAt = null;
+        this.failedLoginAttempts = 0;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+        this.isPasswordExpired = false;
+        this.passwordChangedAt = LocalDateTime.now();
     }
 
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
@@ -3,10 +3,12 @@ package com.backoffice.sosangongin.auth.repos;
 import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AdminRepository extends JpaRepository<BackofficeAdmin, UUID> {
     Optional<BackofficeAdmin> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
+    List<BackofficeAdmin> findByDeletedAtIsNull();
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionAuthenticationFilter.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionAuthenticationFilter.java
@@ -5,7 +5,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,10 +14,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
-@RequiredArgsConstructor
 public class SessionAuthenticationFilter extends OncePerRequestFilter {
-
-    private final SessionManager sessionManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -26,10 +22,12 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
         HttpSession session = request.getSession(false);
 
         if (session != null) {
-            sessionManager.getAccountId(session).ifPresent(accountId -> {
-                String role = sessionManager.getRole(session);
+            Object value = session.getAttribute(SessionManager.ACCOUNT_ID_KEY);
+            if (value instanceof UUID accountId) {
+                Object roleValue = session.getAttribute(SessionManager.ROLE_KEY);
+                String role = roleValue instanceof String r ? r : SessionManager.ROLE_BACKOFFICE_USER;
                 setAuthentication(accountId, role);
-            });
+            }
         }
 
         filterChain.doFilter(request, response);

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
@@ -1,25 +1,32 @@
 package com.backoffice.sosangongin.auth.session;
 
 import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
 
 import java.util.Optional;
 import java.util.UUID;
 
 @Component
+@RequestScope
+@RequiredArgsConstructor
 public class SessionManager {
 
-    private static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
-    private static final String ROLE_KEY = "ROLE";
+    static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
+    static final String ROLE_KEY = "ROLE";
 
     public static final String ROLE_ROOT = "ROLE_ROOT";
     public static final String ROLE_BACKOFFICE_USER = "ROLE_BACKOFFICE_USER";
 
-    public void setAccountId(HttpSession session, UUID accountId) {
+    private final HttpSession session;
+
+    public void afterLogin(UUID accountId, String role) {
         session.setAttribute(ACCOUNT_ID_KEY, accountId);
+        session.setAttribute(ROLE_KEY, role);
     }
 
-    public Optional<UUID> getAccountId(HttpSession session) {
+    public Optional<UUID> getAccountId() {
         Object value = session.getAttribute(ACCOUNT_ID_KEY);
         if (value instanceof UUID accountId) {
             return Optional.of(accountId);
@@ -27,11 +34,7 @@ public class SessionManager {
         return Optional.empty();
     }
 
-    public void setRole(HttpSession session, String role) {
-        session.setAttribute(ROLE_KEY, role);
-    }
-
-    public String getRole(HttpSession session) {
+    public String getRole() {
         Object value = session.getAttribute(ROLE_KEY);
         if (value instanceof String role) {
             return role;
@@ -39,7 +42,7 @@ public class SessionManager {
         return ROLE_BACKOFFICE_USER;
     }
 
-    public void invalidate(HttpSession session) {
+    public void invalidate() {
         session.invalidate();
     }
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -1,7 +1,6 @@
 package com.backoffice.sosangongin.config;
 
 import com.backoffice.sosangongin.auth.session.SessionAuthenticationFilter;
-import com.backoffice.sosangongin.auth.session.SessionManager;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +19,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
     private final CorsConfigurationSource corsConfigurationSource;
-    private final SessionManager sessionManager;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -41,7 +39,7 @@ public class SecurityConfig {
                         })
                 )
                 .addFilterBefore(
-                        new SessionAuthenticationFilter(sessionManager),
+                        new SessionAuthenticationFilter(),
                         UsernamePasswordAuthenticationFilter.class
                 )
                 .authorizeHttpRequests(auth -> auth

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        // TODO: role-permission 브랜치에서 교체 예정
+                        .requestMatchers("/api/account/**").hasRole("ROOT")
                         .anyRequest().authenticated()
                 );
 


### PR DESCRIPTION
## 개요
 - rrot 관리자가 admin 계정을 생성하고 관리할 수 있는 API를 구현합니다.

## 작업 내용
 - 계정 생성 API
 - 계정 목록 조회 API
 - 계정 단건 조회 API
 - 계정 수정 API
 - 계정 삭제 API
 - 계정 잠금 해제 PAI
 - 본인 비밀번호 변경 API
 - root 권한 분기 처리

## 주요 사항
### root 계정 보호
 - SecurityConfig에서 /api/account/** 접근을 ROLE_ROOT로 제한하고 Service 레이어에서 root 계정의 수정/삭제/잠금해제를 추가로 차단합니다.
 // TODO: role-permission 브랜치(예정)에서 SecurityConfig 권한 체크 교체 예정

### 비밀번호 변경 설계
 - 본인 전용으로 한정하여 분리 /me/password

### 초기 비밀번호 정책
 - 계정 생성 시 비밀번호는 loginId와 동일합니다.
 - isPasswordExpired = true로 생성 -> 첫 로그인 시 비밀번호 변경 진행

### soft delete
 - 삭제된 계정은 deleted_at으로 관리합니다.