### PR TITLE
[notice] 공지사항 CRUD 및 상태 관리

### DIFF
--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = loginUseCase.execute(request);
         String role = response.isRoot() ? SessionManager.ROLE_ROOT : SessionManager.ROLE_BACKOFFICE_USER;
-        sessionManager.afterLogin(response.getId(), role);
+        sessionManager.afterLogin(response.getId(), role, response.getName());
         return ResponseEntity.ok(response);
     }
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
@@ -15,15 +15,17 @@ public class SessionManager {
 
     static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
     static final String ROLE_KEY = "ROLE";
+    static final String ADMIN_NAME_KEY = "ADMIN_NAME";
 
     public static final String ROLE_ROOT = "ROLE_ROOT";
     public static final String ROLE_BACKOFFICE_USER = "ROLE_BACKOFFICE_USER";
 
     private final HttpSession session;
 
-    public void afterLogin(UUID accountId, String role) {
+    public void afterLogin(UUID accountId, String role, String adminName) {
         session.setAttribute(ACCOUNT_ID_KEY, accountId);
         session.setAttribute(ROLE_KEY, role);
+        session.setAttribute(ADMIN_NAME_KEY, adminName);
     }
 
     public Optional<UUID> getAccountId() {
@@ -40,6 +42,14 @@ public class SessionManager {
             return role;
         }
         return ROLE_BACKOFFICE_USER;
+    }
+
+    public Optional<String> getAdminName() {
+        Object value = session.getAttribute(ADMIN_NAME_KEY);
+        if (value instanceof String name) {
+            return Optional.of(name);
+        }
+        return Optional.empty();
     }
 
     public void invalidate() {

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -48,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/account/**").hasRole("ROOT")
                         .requestMatchers("/api/role/**").hasRole("ROOT")
                         .requestMatchers("/api/permission/**").hasRole("ROOT")
+                        .requestMatchers("/api/notice/**").authenticated()
                         .anyRequest().authenticated()
                 );
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/PermissionAspect.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/PermissionAspect.java
@@ -1,28 +1,47 @@
 package com.backoffice.sosangongin.global.aop;
 
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
 import com.backoffice.sosangongin.global.exception.PermissionDeniedException;
+import com.backoffice.sosangongin.role.repository.AccountRoleRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class PermissionAspect {
+
+    private final SessionManager sessionManager;
+    private final AccountRoleRepository accountRoleRepository;
 
     @Around("@annotation(requiresPermission)")
     public Object check(ProceedingJoinPoint joinPoint,
                         RequiresPermission requiresPermission) throws Throwable {
-        // TODO: notice 브랜치에서 실제 permission 체크 로직 구현
-        // 1. SecurityContext에서 accountId 꺼내기
-        // 2. accountId로 role 조회
-        // 3. role에 매핑된 permission 목록 조회
-        // 4. requiresPermission.value()와 매칭 여부 확인
-        // 5. (예외 처리) PermissionDeniedException
+        UUID accountId = sessionManager.getAccountId()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
 
-        log.debug("Permission check: {}", requiresPermission.value());
+        if (SessionManager.ROLE_ROOT.equals(sessionManager.getRole())) {
+            return joinPoint.proceed();
+        }
+
+        String requiredPermission = requiresPermission.value();
+
+        boolean hasPermission = accountRoleRepository.findByIdAccountId(accountId)
+                .stream()
+                .flatMap(ar -> ar.getRole().getRolePermissions().stream())
+                .anyMatch(rp -> rp.getPermission().getPermissionName().equals(requiredPermission));
+
+        if (!hasPermission) {
+            throw new PermissionDeniedException("권한이 없습니다.");
+        }
         return joinPoint.proceed();
     }
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/controller/NoticeController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/controller/NoticeController.java
@@ -1,0 +1,66 @@
+package com.backoffice.sosangongin.notice.controller;
+
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.aop.RequiresPermission;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import com.backoffice.sosangongin.notice.dto.*;
+import com.backoffice.sosangongin.notice.usecase.NoticeUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeUseCase noticeUseCase;
+    private final SessionManager sessionManager;
+
+    @GetMapping
+    public ResponseEntity<List<NoticeResponse>> findAll() {
+        return ResponseEntity.ok(noticeUseCase.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NoticeResponse> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(noticeUseCase.findById(id));
+    }
+
+    @PostMapping
+    @RequiresPermission("create.notice")
+    public ResponseEntity<NoticeResponse> create(@RequestBody NoticeCreateRequest request) {
+        UUID createdBy = sessionManager.getAccountId()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        String authorName = sessionManager.getAdminName()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        return ResponseEntity.created(URI.create("/api/notice"))
+                .body(noticeUseCase.create(request, createdBy, authorName));
+    }
+
+    @PatchMapping("/{id}")
+    @RequiresPermission("update.notice")
+    public ResponseEntity<NoticeResponse> update(@PathVariable Long id,
+                                                 @RequestBody NoticeUpdateRequest request) {
+        return ResponseEntity.ok(noticeUseCase.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @RequiresPermission("delete.notice")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        noticeUseCase.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/status")
+    @RequiresPermission("update.notice")
+    public ResponseEntity<Void> changeStatus(@PathVariable Long id,
+                                             @RequestBody NoticeStatusRequest request) {
+        noticeUseCase.changeStatus(id, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/Notice.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/Notice.java
@@ -1,0 +1,67 @@
+package com.backoffice.sosangongin.notice.domain;
+
+import com.backoffice.sosangongin.global.entity.SoftDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "public_notice")
+public class Notice extends SoftDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "author_name")
+    private String authorName;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private NoticeStatus status = NoticeStatus.DRAFT;
+
+    @Builder.Default
+    @Column(name = "is_pinned")
+    private boolean isPinned = false;
+
+    @Builder.Default
+    @Column(name = "is_maintenance")
+    private boolean isServiceMaintenance = false;
+
+    @Column(name = "view_count", insertable = false, updatable = false)
+    @Builder.Default
+    private Long viewCount = 0L;
+
+    @Column(name = "starts_at", nullable = false)
+    private LocalDateTime startsAt;
+
+    @Column(name = "ends_at")
+    private LocalDateTime endsAt;
+
+    public void update(String title, String content, LocalDateTime startsAt, LocalDateTime endsAt, boolean isServiceMaintenance) {
+        this.title = title;
+        this.content = content;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+        this.isServiceMaintenance = isServiceMaintenance;
+    }
+
+    public void changeStatus(NoticeStatus status) {
+        this.status = status;
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/NoticeStatus.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/NoticeStatus.java
@@ -1,0 +1,5 @@
+package com.backoffice.sosangongin.notice.domain;
+
+public enum NoticeStatus {
+    DRAFT, PUBLISHED, HIDDEN
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeCreateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeCreateRequest.java
@@ -1,0 +1,16 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCreateRequest {
+    private String title;
+    private String content;
+    private LocalDateTime startsAt;
+    private LocalDateTime endsAt;
+    private boolean isServiceMaintenance;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeResponse.java
@@ -1,0 +1,43 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import com.backoffice.sosangongin.notice.domain.Notice;
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class NoticeResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private String authorName;
+    private UUID createdBy;
+    private NoticeStatus status;
+    private boolean isPinned;
+    private boolean isServiceMaintenance;
+    private Long viewCount;
+    private LocalDateTime startsAt;
+    private LocalDateTime endsAt;
+    private LocalDateTime createdAt;
+
+    public static NoticeResponse from(Notice notice) {
+        return NoticeResponse.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .authorName(notice.getAuthorName())
+                .createdBy(notice.getCreatedBy())
+                .status(notice.getStatus())
+                .isPinned(notice.isPinned())
+                .isServiceMaintenance(notice.isServiceMaintenance())
+                .viewCount(notice.getViewCount())
+                .startsAt(notice.getStartsAt())
+                .endsAt(notice.getEndsAt())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeStatusRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeStatusRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeStatusRequest {
+    private NoticeStatus status;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeUpdateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeUpdateRequest {
+    private String title;
+    private String content;
+    private LocalDateTime startsAt;
+    private LocalDateTime endsAt;
+    private boolean isServiceMaintenance;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/repository/NoticeRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/repository/NoticeRepository.java
@@ -1,0 +1,14 @@
+package com.backoffice.sosangongin.notice.repository;
+
+import com.backoffice.sosangongin.notice.domain.Notice;
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findByDeletedAtIsNull();
+    Optional<Notice> findByIdAndDeletedAtIsNull(Long id);
+    List<Notice> findByStatusAndDeletedAtIsNull(NoticeStatus status);
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/service/NoticeService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/service/NoticeService.java
@@ -1,0 +1,67 @@
+package com.backoffice.sosangongin.notice.service;
+
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.notice.domain.Notice;
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import com.backoffice.sosangongin.notice.dto.NoticeCreateRequest;
+import com.backoffice.sosangongin.notice.dto.NoticeUpdateRequest;
+import com.backoffice.sosangongin.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public Notice create(NoticeCreateRequest request, UUID createdBy, String authorName) {
+        return noticeRepository.save(
+                Notice.builder()
+                        .title(request.getTitle())
+                        .content(request.getContent())
+                        .authorName(authorName)
+                        .createdBy(createdBy)
+                        .startsAt(request.getStartsAt())
+                        .endsAt(request.getEndsAt())
+                        .isServiceMaintenance(request.isServiceMaintenance())
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<Notice> findAll() {
+        return noticeRepository.findByDeletedAtIsNull();
+    }
+
+    @Transactional(readOnly = true)
+    public Notice findById(Long id) {
+        return noticeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공지사항입니다."));
+    }
+
+    @Transactional
+    public Notice update(Long id, NoticeUpdateRequest request) {
+        Notice notice = findById(id);
+        notice.update(request.getTitle(), request.getContent(),
+                request.getStartsAt(), request.getEndsAt(), request.isServiceMaintenance());
+        return notice;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Notice notice = findById(id);
+        notice.delete();
+    }
+
+    @Transactional
+    public void changeStatus(Long id, NoticeStatus status) {
+        Notice notice = findById(id);
+        notice.changeStatus(status);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/usecase/NoticeUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/usecase/NoticeUseCase.java
@@ -1,0 +1,42 @@
+package com.backoffice.sosangongin.notice.usecase;
+
+import com.backoffice.sosangongin.notice.dto.*;
+import com.backoffice.sosangongin.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeUseCase {
+
+    private final NoticeService noticeService;
+
+    public NoticeResponse create(NoticeCreateRequest request, UUID createdBy, String authorName) {
+        return NoticeResponse.from(noticeService.create(request, createdBy, authorName));
+    }
+
+    public List<NoticeResponse> findAll() {
+        return noticeService.findAll().stream()
+                .map(NoticeResponse::from)
+                .toList();
+    }
+
+    public NoticeResponse findById(Long id) {
+        return NoticeResponse.from(noticeService.findById(id));
+    }
+
+    public NoticeResponse update(Long id, NoticeUpdateRequest request) {
+        return NoticeResponse.from(noticeService.update(id, request));
+    }
+
+    public void delete(Long id) {
+        noticeService.delete(id);
+    }
+
+    public void changeStatus(Long id, NoticeStatusRequest request) {
+        noticeService.changeStatus(id, request.getStatus());
+    }
+}

--- a/_backoffice/backend/src/test/java/com/backoffice/sosangongin/notice/NoticeApiTest.java
+++ b/_backoffice/backend/src/test/java/com/backoffice/sosangongin/notice/NoticeApiTest.java
@@ -1,0 +1,131 @@
+package com.backoffice.sosangongin.notice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NoticeApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpSession rootSession;
+
+    @BeforeEach
+    void login() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        rootSession = (MockHttpSession) result.getRequest().getSession();
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 → 201")
+    void create_notice() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("title", "테스트 공지", "content", "테스트 내용",
+                        "startsAt", "2026-04-04T00:00:00",
+                        "isServiceMaintenance", false));
+
+        mockMvc.perform(post("/api/notice")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("테스트 공지"))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+    }
+
+    @Test
+    @DisplayName("공지사항 전체 조회 → 200")
+    void findAll_notices() throws Exception {
+        mockMvc.perform(get("/api/notice")
+                        .session(rootSession))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("공지사항 상태 변경 → 200")
+    void changeStatus() throws Exception {
+        String createBody = objectMapper.writeValueAsString(
+                Map.of("title", "상태변경 테스트", "content", "내용",
+                        "startsAt", "2026-04-04T00:00:00",
+                        "isServiceMaintenance", false));
+
+        MvcResult createResult = mockMvc.perform(post("/api/notice")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long noticeId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        String statusBody = objectMapper.writeValueAsString(
+                Map.of("status", "PUBLISHED"));
+
+        mockMvc.perform(patch("/api/notice/" + noticeId + "/status")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("공지사항 삭제 → 204")
+    void delete_notice() throws Exception {
+        String createBody = objectMapper.writeValueAsString(
+                Map.of("title", "삭제 테스트", "content", "내용",
+                        "startsAt", "2026-04-04T00:00:00",
+                        "isServiceMaintenance", false));
+
+        MvcResult createResult = mockMvc.perform(post("/api/notice")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long noticeId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        mockMvc.perform(delete("/api/notice/" + noticeId)
+                        .session(rootSession))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("미인증 접근 → 401")
+    void unauthenticated_access() throws Exception {
+        mockMvc.perform(get("/api/notice"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 개요
 - 백오피스 관리자가 공지사항을 작성하고 관리할 수 있는 API 구현

## 작업 내용
 - 공지사항 CRUD API
 - 상태 변경 API (DRAFT/PUBLISHED/HIDDEN)
 - @RequiresPermission 권한 체크 실제 로직 구현
 - ROOT 권한 예외 처리 (바이패스)
 
## 주요 사항
### 권한 체크 방식
 - create.notice, update.notice, delete.notice permission으로 접근 제어
 - ROOT는 permission 체크 없이 가능
 - 조회는 인증된 관리자(admin)면 누구나 가능

### 플랫폼 공유 테이블
 - 플랫폼의 public_notice 테이블을 백오피스에서 직접 관리
 - viewCount는 플랫폼에서 관리 + 백오피스는 읽기만 (null 허용)

### SessionManager 변경
 - afterLogin()에 adminName 추가
 - getAdminName() 메서드 추가
 - 공지 생성 시 세션에서 작성자 이름 자동 저장

## 의존 브랜치
 - backoffice/role-permission -> backoffice/notice