### PR TITLE
[backoffice] 계정 관리, 역할/권한, 공지사항 구현

### DIFF
--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
@@ -7,7 +7,6 @@ import com.backoffice.sosangongin.account.dto.PasswordChangeRequest;
 import com.backoffice.sosangongin.account.usecase.AccountUseCase;
 import com.backoffice.sosangongin.auth.session.SessionManager;
 import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -57,9 +56,8 @@ public class AccountController {
     }
 
     @PatchMapping("/me/password")
-    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request,
-                                               HttpSession session) {
-        UUID requesterId = sessionManager.getAccountId(session)
+    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request) {
+        UUID requesterId = sessionManager.getAccountId()
                 .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
         accountUseCase.changePassword(requesterId, request);
         return ResponseEntity.ok().build();

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
@@ -1,0 +1,67 @@
+package com.backoffice.sosangongin.account.controller;
+
+import com.backoffice.sosangongin.account.dto.AccountCreateRequest;
+import com.backoffice.sosangongin.account.dto.AccountResponse;
+import com.backoffice.sosangongin.account.dto.AccountUpdateRequest;
+import com.backoffice.sosangongin.account.dto.PasswordChangeRequest;
+import com.backoffice.sosangongin.account.usecase.AccountUseCase;
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountUseCase accountUseCase;
+    private final SessionManager sessionManager;
+
+    @PostMapping
+    public ResponseEntity<AccountResponse> create(@RequestBody AccountCreateRequest request) {
+        return ResponseEntity.status(201).body(accountUseCase.create(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AccountResponse>> findAll() {
+        return ResponseEntity.ok(accountUseCase.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AccountResponse> findById(@PathVariable UUID id) {
+        return ResponseEntity.ok(accountUseCase.findById(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<AccountResponse> update(@PathVariable UUID id,
+                                                  @RequestBody AccountUpdateRequest request) {
+        return ResponseEntity.ok(accountUseCase.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        accountUseCase.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/unlock")
+    public ResponseEntity<Void> unlock(@PathVariable UUID id) {
+        accountUseCase.unlock(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request,
+                                               HttpSession session) {
+        UUID requesterId = sessionManager.getAccountId(session)
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        accountUseCase.changePassword(requesterId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountCreateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountCreateRequest.java
@@ -1,0 +1,13 @@
+package com.backoffice.sosangongin.account.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccountCreateRequest {
+    private String loginId;
+    private String name;
+    private String email;
+    private String phoneNumber;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountResponse.java
@@ -1,0 +1,36 @@
+package com.backoffice.sosangongin.account.dto;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class AccountResponse {
+    private UUID id;
+    private String loginId;
+    private String name;
+    private String email;
+    private String phoneNumber;
+    private boolean isRoot;
+    private boolean isLocked;
+    private boolean isPasswordExpired;
+    private LocalDateTime createdAt;
+
+    public static AccountResponse from(BackofficeAdmin admin) {
+        return AccountResponse.builder()
+                .id(admin.getId())
+                .loginId(admin.getLoginId())
+                .name(admin.getName())
+                .email(admin.getEmail())
+                .phoneNumber(admin.getPhoneNumber())
+                .isRoot(admin.isRoot())
+                .isLocked(admin.isLocked())
+                .isPasswordExpired(admin.isPasswordExpired())
+                .createdAt(admin.getCreatedAt())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountUpdateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.backoffice.sosangongin.account.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccountUpdateRequest {
+    private String name;
+    private String email;
+    private String phoneNumber;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/PasswordChangeRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/PasswordChangeRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.account.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PasswordChangeRequest {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/service/AccountService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/service/AccountService.java
@@ -1,0 +1,90 @@
+package com.backoffice.sosangongin.account.service;
+
+import com.backoffice.sosangongin.account.dto.*;
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.auth.repos.AdminRepository;
+import com.backoffice.sosangongin.global.exception.DuplicateResourceException;
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import com.backoffice.sosangongin.global.exception.PermissionDeniedException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public BackofficeAdmin create(AccountCreateRequest request) {
+        if (adminRepository.existsByLoginId(request.getLoginId())) {
+            throw new DuplicateResourceException("이미 존재하는 아이디입니다.");
+        }
+
+        return adminRepository.save(
+                BackofficeAdmin.builder()
+                        .loginId(request.getLoginId())
+                        .password(passwordEncoder.encode(request.getLoginId()))
+                        .name(request.getName())
+                        .email(request.getEmail())
+                        .phoneNumber(request.getPhoneNumber())
+                        .isRoot(false)
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<BackofficeAdmin> findAll() {
+        return adminRepository.findByDeletedAtIsNull();
+    }
+
+    @Transactional(readOnly = true)
+    public BackofficeAdmin findById(UUID id) {
+        return adminRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 계정입니다."));
+    }
+
+    @Transactional
+    public BackofficeAdmin update(UUID id, AccountUpdateRequest request) {
+        BackofficeAdmin admin = findById(id);
+        if (admin.isRoot()) {
+            throw new PermissionDeniedException("root 계정은 수정할 수 없습니다.");
+        }
+        admin.update(request.getName(), request.getEmail(), request.getPhoneNumber());
+        return admin;
+    }
+
+    @Transactional
+    public void delete(UUID id) {
+        BackofficeAdmin admin = findById(id);
+        if (admin.isRoot()) {
+            throw new PermissionDeniedException("root 계정은 삭제할 수 없습니다.");
+        }
+        admin.delete();
+    }
+
+    @Transactional
+    public void unlock(UUID id) {
+        BackofficeAdmin admin = findById(id);
+        if (admin.isRoot()) {
+            throw new PermissionDeniedException("root 계정은 잠금 해제 대상이 아닙니다.");
+        }
+        admin.unlock();
+    }
+
+    @Transactional
+    public void changePassword(UUID id, PasswordChangeRequest request) {
+        BackofficeAdmin admin = findById(id);
+        if (!passwordEncoder.matches(request.getCurrentPassword(), admin.getPassword())) {
+            throw new InvalidCredentialsException("현재 비밀번호가 올바르지 않습니다.");
+        }
+        admin.changePassword(passwordEncoder.encode(request.getNewPassword()));
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/usecase/AccountUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/usecase/AccountUseCase.java
@@ -1,0 +1,47 @@
+package com.backoffice.sosangongin.account.usecase;
+
+import com.backoffice.sosangongin.account.dto.*;
+import com.backoffice.sosangongin.account.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AccountUseCase {
+
+    private final AccountService accountService;
+
+    public AccountResponse create(AccountCreateRequest request) {
+        return AccountResponse.from(accountService.create(request));
+    }
+
+    public List<AccountResponse> findAll() {
+        return accountService.findAll().stream()
+                .map(AccountResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    public AccountResponse findById(UUID id) {
+        return AccountResponse.from(accountService.findById(id));
+    }
+
+    public AccountResponse update(UUID id, AccountUpdateRequest request) {
+        return AccountResponse.from(accountService.update(id, request));
+    }
+
+    public void delete(UUID id) {
+        accountService.delete(id);
+    }
+
+    public void unlock(UUID id) {
+        accountService.unlock(id);
+    }
+
+    public void changePassword(UUID requesterId, PasswordChangeRequest request) {
+        accountService.changePassword(requesterId, request);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
@@ -20,7 +20,7 @@ public class AuthController {
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
         LoginResponse response = loginUseCase.execute(request);
         String role = response.isRoot() ? SessionManager.ROLE_ROOT : SessionManager.ROLE_BACKOFFICE_USER;
-        sessionManager.afterLogin(response.getId(), role);
+        sessionManager.afterLogin(response.getId(), role, response.getName());
         return ResponseEntity.ok(response);
     }
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
@@ -44,8 +44,8 @@ public class BackofficeAdmin extends SoftDeletedBaseEntity {
     @Column(name = "is_password_expired", nullable = false)
     private boolean isPasswordExpired = true;
 
-    // @Column(name = "password_changed_at")
-    // private LocalDateTime passwordChangedAt;
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
 
     @Column(name = "failed_login_attempts", nullable = false)
     private int failedLoginAttempts = 0;
@@ -67,6 +67,24 @@ public class BackofficeAdmin extends SoftDeletedBaseEntity {
 
     public void resetFailedAttempts() {
         this.failedLoginAttempts = 0;
+    }
+
+    public void update(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void unlock() {
+        this.isLocked = false;
+        this.lockedAt = null;
+        this.failedLoginAttempts = 0;
+    }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+        this.isPasswordExpired = false;
+        this.passwordChangedAt = LocalDateTime.now();
     }
 
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/domain/BackofficeAdmin.java
@@ -42,15 +42,18 @@ public class BackofficeAdmin extends SoftDeletedBaseEntity {
     private boolean isRoot = false;
 
     @Column(name = "is_password_expired", nullable = false)
+    @Builder.Default
     private boolean isPasswordExpired = true;
 
     @Column(name = "password_changed_at")
     private LocalDateTime passwordChangedAt;
 
     @Column(name = "failed_login_attempts", nullable = false)
+    @Builder.Default
     private int failedLoginAttempts = 0;
 
     @Column(name = "is_locked", nullable = false)
+    @Builder.Default
     private boolean isLocked = false;
 
     @Column(name = "locked_at")

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/init/RootAdminInitializer.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/init/RootAdminInitializer.java
@@ -24,6 +24,7 @@ public class RootAdminInitializer implements ApplicationRunner {
                             .password(passwordEncoder.encode("root"))
                             .name("root")
                             .isRoot(true)
+                            .isPasswordExpired(false)
                             .build()
             );
         }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
@@ -3,10 +3,12 @@ package com.backoffice.sosangongin.auth.repos;
 import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface AdminRepository extends JpaRepository<BackofficeAdmin, UUID> {
     Optional<BackofficeAdmin> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
+    List<BackofficeAdmin> findByDeletedAtIsNull();
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/service/AuthService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/service/AuthService.java
@@ -18,6 +18,7 @@ public class AuthService {
 
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
+    private final LoginAttemptService loginAttemptService;
 
     @Transactional
     public BackofficeAdmin authenticate(String loginId, String password) {
@@ -29,10 +30,7 @@ public class AuthService {
         }
 
         if (!passwordEncoder.matches(password, admin.getPassword())) {
-            admin.increaseFailedAttempts();
-            if (admin.getFailedLoginAttempts() >= MAX_FAILED_ATTEMPTS) {
-                admin.lock();
-            }
+            loginAttemptService.handleFailedAttempt(admin);
             throw new InvalidCredentialsException("비밀번호가 올바르지 않습니다.");
         }
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/service/LoginAttemptService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/service/LoginAttemptService.java
@@ -1,0 +1,31 @@
+package com.backoffice.sosangongin.auth.service;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.auth.repos.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LoginAttemptService {
+
+    private static final int MAX_FAILED_ATTEMPTS = 5;
+    private final AdminRepository adminRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)  // 핵심 - 별도 트랜잭션
+    public void handleFailedAttempt(BackofficeAdmin admin) {
+        admin.increaseFailedAttempts();
+        if (admin.getFailedLoginAttempts() >= MAX_FAILED_ATTEMPTS) {
+            admin.lock();
+        }
+        adminRepository.saveAndFlush(admin);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleSuccess(BackofficeAdmin admin) {
+        admin.resetFailedAttempts();
+        adminRepository.saveAndFlush(admin);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
@@ -15,15 +15,17 @@ public class SessionManager {
 
     static final String ACCOUNT_ID_KEY = "ACCOUNT_ID";
     static final String ROLE_KEY = "ROLE";
+    static final String ADMIN_NAME_KEY = "ADMIN_NAME";
 
     public static final String ROLE_ROOT = "ROLE_ROOT";
     public static final String ROLE_BACKOFFICE_USER = "ROLE_BACKOFFICE_USER";
 
     private final HttpSession session;
 
-    public void afterLogin(UUID accountId, String role) {
+    public void afterLogin(UUID accountId, String role, String adminName) {
         session.setAttribute(ACCOUNT_ID_KEY, accountId);
         session.setAttribute(ROLE_KEY, role);
+        session.setAttribute(ADMIN_NAME_KEY, adminName);
     }
 
     public Optional<UUID> getAccountId() {
@@ -40,6 +42,14 @@ public class SessionManager {
             return role;
         }
         return ROLE_BACKOFFICE_USER;
+    }
+
+    public Optional<String> getAdminName() {
+        Object value = session.getAttribute(ADMIN_NAME_KEY);
+        if (value instanceof String name) {
+            return Optional.of(name);
+        }
+        return Optional.empty();
     }
 
     public void invalidate() {

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -48,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/account/**").hasRole("ROOT")
                         .requestMatchers("/api/role/**").hasRole("ROOT")
                         .requestMatchers("/api/permission/**").hasRole("ROOT")
+                        .requestMatchers("/api/notice/**").authenticated()
                         .anyRequest().authenticated()
                 );
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        // TODO: role-permission 브랜치에서 교체 예정
+                        .requestMatchers("/api/account/**").hasRole("ROOT")
                         .anyRequest().authenticated()
                 );
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -44,8 +44,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
-                        // TODO: role-permission 브랜치에서 교체 예정
+                        .requestMatchers("/api/account/me/password").authenticated()
                         .requestMatchers("/api/account/**").hasRole("ROOT")
+                        .requestMatchers("/api/role/**").hasRole("ROOT")
+                        .requestMatchers("/api/permission/**").hasRole("ROOT")
                         .anyRequest().authenticated()
                 );
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/PermissionAspect.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/PermissionAspect.java
@@ -1,28 +1,47 @@
 package com.backoffice.sosangongin.global.aop;
 
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
 import com.backoffice.sosangongin.global.exception.PermissionDeniedException;
+import com.backoffice.sosangongin.role.repository.AccountRoleRepository;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class PermissionAspect {
+
+    private final SessionManager sessionManager;
+    private final AccountRoleRepository accountRoleRepository;
 
     @Around("@annotation(requiresPermission)")
     public Object check(ProceedingJoinPoint joinPoint,
                         RequiresPermission requiresPermission) throws Throwable {
-        // TODO: notice 브랜치에서 실제 permission 체크 로직 구현
-        // 1. SecurityContext에서 accountId 꺼내기
-        // 2. accountId로 role 조회
-        // 3. role에 매핑된 permission 목록 조회
-        // 4. requiresPermission.value()와 매칭 여부 확인
-        // 5. (예외 처리) PermissionDeniedException
+        UUID accountId = sessionManager.getAccountId()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
 
-        log.debug("Permission check: {}", requiresPermission.value());
+        if (SessionManager.ROLE_ROOT.equals(sessionManager.getRole())) {
+            return joinPoint.proceed();
+        }
+
+        String requiredPermission = requiresPermission.value();
+
+        boolean hasPermission = accountRoleRepository.findByIdAccountId(accountId)
+                .stream()
+                .flatMap(ar -> ar.getRole().getRolePermissions().stream())
+                .anyMatch(rp -> rp.getPermission().getPermissionName().equals(requiredPermission));
+
+        if (!hasPermission) {
+            throw new PermissionDeniedException("권한이 없습니다.");
+        }
         return joinPoint.proceed();
     }
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/PermissionAspect.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/PermissionAspect.java
@@ -1,0 +1,28 @@
+package com.backoffice.sosangongin.global.aop;
+
+import com.backoffice.sosangongin.global.exception.PermissionDeniedException;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class PermissionAspect {
+
+    @Around("@annotation(requiresPermission)")
+    public Object check(ProceedingJoinPoint joinPoint,
+                        RequiresPermission requiresPermission) throws Throwable {
+        // TODO: notice 브랜치에서 실제 permission 체크 로직 구현
+        // 1. SecurityContext에서 accountId 꺼내기
+        // 2. accountId로 role 조회
+        // 3. role에 매핑된 permission 목록 조회
+        // 4. requiresPermission.value()와 매칭 여부 확인
+        // 5. (예외 처리) PermissionDeniedException
+
+        log.debug("Permission check: {}", requiresPermission.value());
+        return joinPoint.proceed();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/RequiresPermission.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/aop/RequiresPermission.java
@@ -1,0 +1,12 @@
+package com.backoffice.sosangongin.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiresPermission {
+    String value();
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/controller/NoticeController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/controller/NoticeController.java
@@ -1,0 +1,66 @@
+package com.backoffice.sosangongin.notice.controller;
+
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.aop.RequiresPermission;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import com.backoffice.sosangongin.notice.dto.*;
+import com.backoffice.sosangongin.notice.usecase.NoticeUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeUseCase noticeUseCase;
+    private final SessionManager sessionManager;
+
+    @GetMapping
+    public ResponseEntity<List<NoticeResponse>> findAll() {
+        return ResponseEntity.ok(noticeUseCase.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<NoticeResponse> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(noticeUseCase.findById(id));
+    }
+
+    @PostMapping
+    @RequiresPermission("create.notice")
+    public ResponseEntity<NoticeResponse> create(@RequestBody NoticeCreateRequest request) {
+        UUID createdBy = sessionManager.getAccountId()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        String authorName = sessionManager.getAdminName()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        return ResponseEntity.created(URI.create("/api/notice"))
+                .body(noticeUseCase.create(request, createdBy, authorName));
+    }
+
+    @PatchMapping("/{id}")
+    @RequiresPermission("update.notice")
+    public ResponseEntity<NoticeResponse> update(@PathVariable Long id,
+                                                 @RequestBody NoticeUpdateRequest request) {
+        return ResponseEntity.ok(noticeUseCase.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @RequiresPermission("delete.notice")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        noticeUseCase.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{id}/status")
+    @RequiresPermission("update.notice")
+    public ResponseEntity<Void> changeStatus(@PathVariable Long id,
+                                             @RequestBody NoticeStatusRequest request) {
+        noticeUseCase.changeStatus(id, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/Notice.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/Notice.java
@@ -1,0 +1,67 @@
+package com.backoffice.sosangongin.notice.domain;
+
+import com.backoffice.sosangongin.global.entity.SoftDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "public_notice")
+public class Notice extends SoftDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "author_name")
+    private String authorName;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private NoticeStatus status = NoticeStatus.DRAFT;
+
+    @Builder.Default
+    @Column(name = "is_pinned")
+    private boolean isPinned = false;
+
+    @Builder.Default
+    @Column(name = "is_maintenance")
+    private boolean isServiceMaintenance = false;
+
+    @Column(name = "view_count", insertable = false, updatable = false)
+    @Builder.Default
+    private Long viewCount = 0L;
+
+    @Column(name = "starts_at", nullable = false)
+    private LocalDateTime startsAt;
+
+    @Column(name = "ends_at")
+    private LocalDateTime endsAt;
+
+    public void update(String title, String content, LocalDateTime startsAt, LocalDateTime endsAt, boolean isServiceMaintenance) {
+        this.title = title;
+        this.content = content;
+        this.startsAt = startsAt;
+        this.endsAt = endsAt;
+        this.isServiceMaintenance = isServiceMaintenance;
+    }
+
+    public void changeStatus(NoticeStatus status) {
+        this.status = status;
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/NoticeStatus.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/domain/NoticeStatus.java
@@ -1,0 +1,5 @@
+package com.backoffice.sosangongin.notice.domain;
+
+public enum NoticeStatus {
+    DRAFT, PUBLISHED, HIDDEN
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeCreateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeCreateRequest.java
@@ -1,0 +1,16 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeCreateRequest {
+    private String title;
+    private String content;
+    private LocalDateTime startsAt;
+    private LocalDateTime endsAt;
+    private boolean isServiceMaintenance;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeResponse.java
@@ -1,0 +1,43 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import com.backoffice.sosangongin.notice.domain.Notice;
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class NoticeResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private String authorName;
+    private UUID createdBy;
+    private NoticeStatus status;
+    private boolean isPinned;
+    private boolean isServiceMaintenance;
+    private Long viewCount;
+    private LocalDateTime startsAt;
+    private LocalDateTime endsAt;
+    private LocalDateTime createdAt;
+
+    public static NoticeResponse from(Notice notice) {
+        return NoticeResponse.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .content(notice.getContent())
+                .authorName(notice.getAuthorName())
+                .createdBy(notice.getCreatedBy())
+                .status(notice.getStatus())
+                .isPinned(notice.isPinned())
+                .isServiceMaintenance(notice.isServiceMaintenance())
+                .viewCount(notice.getViewCount())
+                .startsAt(notice.getStartsAt())
+                .endsAt(notice.getEndsAt())
+                .createdAt(notice.getCreatedAt())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeStatusRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeStatusRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoticeStatusRequest {
+    private NoticeStatus status;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeUpdateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/dto/NoticeUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.backoffice.sosangongin.notice.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class NoticeUpdateRequest {
+    private String title;
+    private String content;
+    private LocalDateTime startsAt;
+    private LocalDateTime endsAt;
+    private boolean isServiceMaintenance;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/repository/NoticeRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/repository/NoticeRepository.java
@@ -1,0 +1,14 @@
+package com.backoffice.sosangongin.notice.repository;
+
+import com.backoffice.sosangongin.notice.domain.Notice;
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findByDeletedAtIsNull();
+    Optional<Notice> findByIdAndDeletedAtIsNull(Long id);
+    List<Notice> findByStatusAndDeletedAtIsNull(NoticeStatus status);
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/service/NoticeService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/service/NoticeService.java
@@ -1,0 +1,67 @@
+package com.backoffice.sosangongin.notice.service;
+
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.notice.domain.Notice;
+import com.backoffice.sosangongin.notice.domain.NoticeStatus;
+import com.backoffice.sosangongin.notice.dto.NoticeCreateRequest;
+import com.backoffice.sosangongin.notice.dto.NoticeUpdateRequest;
+import com.backoffice.sosangongin.notice.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public Notice create(NoticeCreateRequest request, UUID createdBy, String authorName) {
+        return noticeRepository.save(
+                Notice.builder()
+                        .title(request.getTitle())
+                        .content(request.getContent())
+                        .authorName(authorName)
+                        .createdBy(createdBy)
+                        .startsAt(request.getStartsAt())
+                        .endsAt(request.getEndsAt())
+                        .isServiceMaintenance(request.isServiceMaintenance())
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<Notice> findAll() {
+        return noticeRepository.findByDeletedAtIsNull();
+    }
+
+    @Transactional(readOnly = true)
+    public Notice findById(Long id) {
+        return noticeRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 공지사항입니다."));
+    }
+
+    @Transactional
+    public Notice update(Long id, NoticeUpdateRequest request) {
+        Notice notice = findById(id);
+        notice.update(request.getTitle(), request.getContent(),
+                request.getStartsAt(), request.getEndsAt(), request.isServiceMaintenance());
+        return notice;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Notice notice = findById(id);
+        notice.delete();
+    }
+
+    @Transactional
+    public void changeStatus(Long id, NoticeStatus status) {
+        Notice notice = findById(id);
+        notice.changeStatus(status);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/usecase/NoticeUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/notice/usecase/NoticeUseCase.java
@@ -1,0 +1,42 @@
+package com.backoffice.sosangongin.notice.usecase;
+
+import com.backoffice.sosangongin.notice.dto.*;
+import com.backoffice.sosangongin.notice.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeUseCase {
+
+    private final NoticeService noticeService;
+
+    public NoticeResponse create(NoticeCreateRequest request, UUID createdBy, String authorName) {
+        return NoticeResponse.from(noticeService.create(request, createdBy, authorName));
+    }
+
+    public List<NoticeResponse> findAll() {
+        return noticeService.findAll().stream()
+                .map(NoticeResponse::from)
+                .toList();
+    }
+
+    public NoticeResponse findById(Long id) {
+        return NoticeResponse.from(noticeService.findById(id));
+    }
+
+    public NoticeResponse update(Long id, NoticeUpdateRequest request) {
+        return NoticeResponse.from(noticeService.update(id, request));
+    }
+
+    public void delete(Long id) {
+        noticeService.delete(id);
+    }
+
+    public void changeStatus(Long id, NoticeStatusRequest request) {
+        noticeService.changeStatus(id, request.getStatus());
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/controller/PermissionController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/controller/PermissionController.java
@@ -1,0 +1,45 @@
+package com.backoffice.sosangongin.permission.controller;
+
+import com.backoffice.sosangongin.permission.dto.*;
+import com.backoffice.sosangongin.permission.usecase.PermissionUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/permission")
+@RequiredArgsConstructor
+public class PermissionController {
+
+    private final PermissionUseCase permissionUseCase;
+
+    @PostMapping
+    public ResponseEntity<PermissionResponse> create(@RequestBody PermissionRequest request) {
+        return ResponseEntity.created(URI.create("/api/permission")).body(permissionUseCase.create(request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PermissionResponse>> findAll() {
+        return ResponseEntity.ok(permissionUseCase.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PermissionResponse> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(permissionUseCase.findById(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PermissionResponse> update(@PathVariable Long id,
+                                                     @RequestBody PermissionRequest request) {
+        return ResponseEntity.ok(permissionUseCase.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        permissionUseCase.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/domain/PermissionBackoffice.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/domain/PermissionBackoffice.java
@@ -1,0 +1,29 @@
+package com.backoffice.sosangongin.permission.domain;
+
+import com.backoffice.sosangongin.global.entity.SoftDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "permission_backoffice")
+public class PermissionBackoffice extends SoftDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "permission_name", nullable = false)
+    private String permissionName;
+
+    @Column(name = "perm_domain", nullable = false)
+    private String permDomain;
+
+    public void update(String permissionName, String permDomain) {
+        this.permissionName = permissionName;
+        this.permDomain = permDomain;
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/dto/PermissionRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/dto/PermissionRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.permission.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PermissionRequest {
+    private String permissionName;
+    private String permDomain;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/dto/PermissionResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/dto/PermissionResponse.java
@@ -1,0 +1,21 @@
+package com.backoffice.sosangongin.permission.dto;
+
+import com.backoffice.sosangongin.permission.domain.PermissionBackoffice;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PermissionResponse {
+    private Long id;
+    private String permissionName;
+    private String permDomain;
+
+    public static PermissionResponse from(PermissionBackoffice permission) {
+        return PermissionResponse.builder()
+                .id(permission.getId())
+                .permissionName(permission.getPermissionName())
+                .permDomain(permission.getPermDomain())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/init/PermissionInitializer.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/init/PermissionInitializer.java
@@ -1,0 +1,33 @@
+package com.backoffice.sosangongin.permission.init;
+
+import com.backoffice.sosangongin.permission.domain.PermissionBackoffice;
+import com.backoffice.sosangongin.permission.repository.PermissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+public class PermissionInitializer implements ApplicationRunner {
+
+    private final PermissionRepository permissionRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (permissionRepository.count() == 0) {
+            permissionRepository.saveAll(List.of(
+                    PermissionBackoffice.builder().permissionName("create.notice").permDomain("notice").build(),
+                    PermissionBackoffice.builder().permissionName("update.notice").permDomain("notice").build(),
+                    PermissionBackoffice.builder().permissionName("delete.notice").permDomain("notice").build(),
+                    PermissionBackoffice.builder().permissionName("create.term").permDomain("term").build(),
+                    PermissionBackoffice.builder().permissionName("update.term").permDomain("term").build(),
+                    PermissionBackoffice.builder().permissionName("delete.term").permDomain("term").build()
+            ));
+        }
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/repository/PermissionRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/repository/PermissionRepository.java
@@ -1,0 +1,12 @@
+package com.backoffice.sosangongin.permission.repository;
+
+import com.backoffice.sosangongin.permission.domain.PermissionBackoffice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PermissionRepository extends JpaRepository<PermissionBackoffice, Long> {
+    List<PermissionBackoffice> findByDeletedAtIsNull();
+    List<PermissionBackoffice> findByIdInAndDeletedAtIsNull(List<Long> ids);
+    boolean existsByPermissionNameAndPermDomain(String permissionName, String permDomain);
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/service/PermissionService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/service/PermissionService.java
@@ -1,0 +1,55 @@
+package com.backoffice.sosangongin.permission.service;
+
+import com.backoffice.sosangongin.global.exception.DuplicateResourceException;
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.permission.domain.PermissionBackoffice;
+import com.backoffice.sosangongin.permission.repository.PermissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PermissionService {
+
+    private final PermissionRepository permissionRepository;
+
+    @Transactional
+    public PermissionBackoffice create(String permissionName, String permDomain) {
+        if (permissionRepository.existsByPermissionNameAndPermDomain(permissionName, permDomain)) {
+            throw new DuplicateResourceException("이미 존재하는 permission입니다.");
+        }
+        return permissionRepository.save(
+                PermissionBackoffice.builder()
+                        .permissionName(permissionName)
+                        .permDomain(permDomain)
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<PermissionBackoffice> findAll() {
+        return permissionRepository.findByDeletedAtIsNull();
+    }
+
+    @Transactional(readOnly = true)
+    public PermissionBackoffice findById(Long id) {
+        return permissionRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 permission입니다."));
+    }
+
+    @Transactional
+    public PermissionBackoffice update(Long id, String permissionName, String permDomain) {
+        PermissionBackoffice permission = findById(id);
+        permission.update(permissionName, permDomain);
+        return permission;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        PermissionBackoffice permission = findById(id);
+        permission.delete();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/usecase/PermissionUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/permission/usecase/PermissionUseCase.java
@@ -1,0 +1,37 @@
+package com.backoffice.sosangongin.permission.usecase;
+
+import com.backoffice.sosangongin.permission.dto.*;
+import com.backoffice.sosangongin.permission.service.PermissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PermissionUseCase {
+
+    private final PermissionService permissionService;
+
+    public PermissionResponse create(PermissionRequest request) {
+        return PermissionResponse.from(permissionService.create(request.getPermissionName(), request.getPermDomain()));
+    }
+
+    public List<PermissionResponse> findAll() {
+        return permissionService.findAll().stream()
+                .map(PermissionResponse::from)
+                .toList();
+    }
+
+    public PermissionResponse findById(Long id) {
+        return PermissionResponse.from(permissionService.findById(id));
+    }
+
+    public PermissionResponse update(Long id, PermissionRequest request) {
+        return PermissionResponse.from(permissionService.update(id, request.getPermissionName(), request.getPermDomain()));
+    }
+
+    public void delete(Long id) {
+        permissionService.delete(id);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/controller/RoleController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/controller/RoleController.java
@@ -1,0 +1,71 @@
+package com.backoffice.sosangongin.role.controller;
+
+import com.backoffice.sosangongin.auth.session.SessionManager;
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import com.backoffice.sosangongin.role.dto.*;
+import com.backoffice.sosangongin.role.usecase.RoleUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/role")
+@RequiredArgsConstructor
+public class RoleController {
+
+    private final RoleUseCase roleUseCase;
+    private final SessionManager sessionManager;
+
+    @PostMapping
+    public ResponseEntity<RoleResponse> create(@RequestBody RoleRequest request) {
+        UUID createdBy = sessionManager.getAccountId()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+        return ResponseEntity.created(URI.create("/api/role")).body(roleUseCase.create(request, createdBy));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<RoleResponse>> findAll() {
+        return ResponseEntity.ok(roleUseCase.findAll());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RoleResponse> findById(@PathVariable Long id) {
+        return ResponseEntity.ok(roleUseCase.findById(id));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<RoleResponse> update(@PathVariable Long id, @RequestBody RoleRequest request) {
+        return ResponseEntity.ok(roleUseCase.update(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        roleUseCase.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/{id}/permissions")
+    public ResponseEntity<Void> updatePermissions(@PathVariable Long id,
+                                                  @RequestBody RolePermissionRequest request) {
+        roleUseCase.updatePermissions(id, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{roleId}/account/{accountId}")
+    public ResponseEntity<Void> assignRole(@PathVariable Long roleId,
+                                           @PathVariable UUID accountId) {
+        roleUseCase.assignRoleToAccount(accountId, roleId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{roleId}/account/{accountId}")
+    public ResponseEntity<Void> removeRole(@PathVariable Long roleId,
+                                           @PathVariable UUID accountId) {
+        roleUseCase.removeRoleFromAccount(accountId, roleId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/AccountRole.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/AccountRole.java
@@ -1,0 +1,27 @@
+package com.backoffice.sosangongin.role.domain;
+
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "account_roles_backoffice")
+public class AccountRole {
+
+    @EmbeddedId
+    private AccountRoleId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("accountId")
+    @JoinColumn(name = "account_id")
+    private BackofficeAdmin account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("roleId")
+    @JoinColumn(name = "role_id")
+    private RoleBackoffice role;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/AccountRoleId.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/AccountRoleId.java
@@ -1,0 +1,17 @@
+package com.backoffice.sosangongin.role.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class AccountRoleId implements Serializable {
+    private UUID accountId;
+    private Long roleId;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/RoleBackoffice.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/RoleBackoffice.java
@@ -1,0 +1,45 @@
+package com.backoffice.sosangongin.role.domain;
+
+import com.backoffice.sosangongin.global.entity.SoftDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "role_backoffice")
+public class RoleBackoffice extends SoftDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "role_name", unique = true, nullable = false)
+    private String roleName;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "created_by")
+    private UUID createdBy;
+
+    @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<RolePermission> rolePermissions = new ArrayList<>();
+
+    public void update(String roleName, String description) {
+        this.roleName = roleName;
+        this.description = description;
+    }
+
+    public void updatePermissions(List<RolePermission> newPermissions) {
+        this.rolePermissions.clear();
+        this.rolePermissions.addAll(newPermissions);
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/RolePermission.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/RolePermission.java
@@ -1,0 +1,27 @@
+package com.backoffice.sosangongin.role.domain;
+
+import com.backoffice.sosangongin.permission.domain.PermissionBackoffice;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "role_permissions_backoffice")
+public class RolePermission {
+
+    @EmbeddedId
+    private RolePermissionId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("roleId")
+    @JoinColumn(name = "role_id")
+    private RoleBackoffice role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("permissionId")
+    @JoinColumn(name = "permission_id")
+    private PermissionBackoffice permission;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/RolePermissionId.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/domain/RolePermissionId.java
@@ -1,0 +1,16 @@
+package com.backoffice.sosangongin.role.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class RolePermissionId implements Serializable {
+    private Long roleId;
+    private Long permissionId;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/dto/RolePermissionRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/dto/RolePermissionRequest.java
@@ -1,0 +1,12 @@
+package com.backoffice.sosangongin.role.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class RolePermissionRequest {
+    private List<Long> permissionIds;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/dto/RoleRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/dto/RoleRequest.java
@@ -1,0 +1,11 @@
+package com.backoffice.sosangongin.role.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RoleRequest {
+    private String roleName;
+    private String description;
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/dto/RoleResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/dto/RoleResponse.java
@@ -1,0 +1,28 @@
+package com.backoffice.sosangongin.role.dto;
+
+import com.backoffice.sosangongin.permission.dto.PermissionResponse;
+import com.backoffice.sosangongin.role.domain.RoleBackoffice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RoleResponse {
+    private Long id;
+    private String roleName;
+    private String description;
+    private List<PermissionResponse> permissions;
+
+    public static RoleResponse from(RoleBackoffice role) {
+        return RoleResponse.builder()
+                .id(role.getId())
+                .roleName(role.getRoleName())
+                .description(role.getDescription())
+                .permissions(role.getRolePermissions().stream()
+                        .map(rp -> PermissionResponse.from(rp.getPermission()))
+                        .toList())
+                .build();
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/repository/AccountRoleRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/repository/AccountRoleRepository.java
@@ -1,0 +1,13 @@
+package com.backoffice.sosangongin.role.repository;
+
+import com.backoffice.sosangongin.role.domain.AccountRole;
+import com.backoffice.sosangongin.role.domain.AccountRoleId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AccountRoleRepository extends JpaRepository<AccountRole, AccountRoleId> {
+    List<AccountRole> findByIdAccountId(UUID accountId);
+    void deleteByIdAccountId(UUID accountId);
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/repository/RoleRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/repository/RoleRepository.java
@@ -1,0 +1,13 @@
+package com.backoffice.sosangongin.role.repository;
+
+import com.backoffice.sosangongin.role.domain.RoleBackoffice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<RoleBackoffice, Long> {
+    boolean existsByRoleName(String roleName);
+    Optional<RoleBackoffice> findByIdAndDeletedAtIsNull(Long id);
+    List<RoleBackoffice> findByDeletedAtIsNull();
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/service/RoleService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/service/RoleService.java
@@ -1,0 +1,110 @@
+package com.backoffice.sosangongin.role.service;
+
+import com.backoffice.sosangongin.account.service.AccountService;
+import com.backoffice.sosangongin.auth.domain.BackofficeAdmin;
+import com.backoffice.sosangongin.global.exception.DuplicateResourceException;
+import com.backoffice.sosangongin.global.exception.EntityNotFoundException;
+import com.backoffice.sosangongin.permission.domain.PermissionBackoffice;
+import com.backoffice.sosangongin.permission.repository.PermissionRepository;
+import com.backoffice.sosangongin.role.domain.AccountRole;
+import com.backoffice.sosangongin.role.domain.AccountRoleId;
+import com.backoffice.sosangongin.role.domain.RoleBackoffice;
+import com.backoffice.sosangongin.role.domain.RolePermission;
+import com.backoffice.sosangongin.role.domain.RolePermissionId;
+import com.backoffice.sosangongin.role.repository.AccountRoleRepository;
+import com.backoffice.sosangongin.role.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RoleService {
+
+    private final RoleRepository roleRepository;
+    private final PermissionRepository permissionRepository;
+    private final AccountRoleRepository accountRoleRepository;
+    private final AccountService accountService;
+
+    @Transactional
+    public RoleBackoffice create(String roleName, String description, UUID createdBy) {
+        if (roleRepository.existsByRoleName(roleName)) {
+            throw new DuplicateResourceException("이미 존재하는 role입니다.");
+        }
+        return roleRepository.save(
+                RoleBackoffice.builder()
+                        .roleName(roleName)
+                        .description(description)
+                        .createdBy(createdBy)
+                        .build()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<RoleBackoffice> findAll() {
+        return roleRepository.findByDeletedAtIsNull();
+    }
+
+    @Transactional(readOnly = true)
+    public RoleBackoffice findById(Long id) {
+        return roleRepository.findByIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 role입니다."));
+    }
+
+    @Transactional
+    public RoleBackoffice update(Long id, String roleName, String description) {
+        RoleBackoffice role = findById(id);
+        role.update(roleName, description);
+        return role;
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        RoleBackoffice role = findById(id);
+        role.delete();
+    }
+
+    @Transactional
+    public void updatePermissions(Long roleId, List<Long> permissionIds) {
+        RoleBackoffice role = findById(roleId);
+        List<PermissionBackoffice> permissions = permissionRepository.findByIdInAndDeletedAtIsNull(permissionIds);
+
+        if (permissions.size() != permissionIds.size()) {
+            throw new EntityNotFoundException("존재하지 않는 permission이 포함되어 있습니다.");
+        }
+
+        List<RolePermission> newMappings = permissions.stream()
+                .map(p -> RolePermission.builder()
+                        .id(new RolePermissionId(roleId, p.getId()))
+                        .role(role)
+                        .permission(p)
+                        .build())
+                .toList();
+
+        role.updatePermissions(newMappings);
+    }
+
+    @Transactional
+    public void assignRoleToAccount(UUID accountId, Long roleId) {
+        BackofficeAdmin account = accountService.findById(accountId);
+        RoleBackoffice role = findById(roleId);
+        AccountRoleId id = new AccountRoleId(accountId, roleId);
+        if (!accountRoleRepository.existsById(id)) {
+            accountRoleRepository.save(
+                    AccountRole.builder()
+                            .id(id)
+                            .account(account)
+                            .role(role)
+                            .build()
+            );
+        }
+    }
+
+    @Transactional
+    public void removeRoleFromAccount(UUID accountId, Long roleId) {
+        accountRoleRepository.deleteById(new AccountRoleId(accountId, roleId));
+    }
+}

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/usecase/RoleUseCase.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/role/usecase/RoleUseCase.java
@@ -1,0 +1,50 @@
+package com.backoffice.sosangongin.role.usecase;
+
+import com.backoffice.sosangongin.role.dto.*;
+import com.backoffice.sosangongin.role.service.RoleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class RoleUseCase {
+
+    private final RoleService roleService;
+
+    public RoleResponse create(RoleRequest request, UUID createdBy) {
+        return RoleResponse.from(roleService.create(request.getRoleName(), request.getDescription(), createdBy));
+    }
+
+    public List<RoleResponse> findAll() {
+        return roleService.findAll().stream()
+                .map(RoleResponse::from)
+                .toList();
+    }
+
+    public RoleResponse findById(Long id) {
+        return RoleResponse.from(roleService.findById(id));
+    }
+
+    public RoleResponse update(Long id, RoleRequest request) {
+        return RoleResponse.from(roleService.update(id, request.getRoleName(), request.getDescription()));
+    }
+
+    public void delete(Long id) {
+        roleService.delete(id);
+    }
+
+    public void updatePermissions(Long roleId, RolePermissionRequest request) {
+        roleService.updatePermissions(roleId, request.getPermissionIds());
+    }
+
+    public void assignRoleToAccount(UUID accountId, Long roleId) {
+        roleService.assignRoleToAccount(accountId, roleId);
+    }
+
+    public void removeRoleFromAccount(UUID accountId, Long roleId) {
+        roleService.removeRoleFromAccount(accountId, roleId);
+    }
+}

--- a/_backoffice/backend/src/test/java/com/backoffice/sosangongin/notice/NoticeApiTest.java
+++ b/_backoffice/backend/src/test/java/com/backoffice/sosangongin/notice/NoticeApiTest.java
@@ -1,0 +1,131 @@
+package com.backoffice.sosangongin.notice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NoticeApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpSession rootSession;
+
+    @BeforeEach
+    void login() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        rootSession = (MockHttpSession) result.getRequest().getSession();
+    }
+
+    @Test
+    @DisplayName("공지사항 생성 → 201")
+    void create_notice() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("title", "테스트 공지", "content", "테스트 내용",
+                        "startsAt", "2026-04-04T00:00:00",
+                        "isServiceMaintenance", false));
+
+        mockMvc.perform(post("/api/notice")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("테스트 공지"))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+    }
+
+    @Test
+    @DisplayName("공지사항 전체 조회 → 200")
+    void findAll_notices() throws Exception {
+        mockMvc.perform(get("/api/notice")
+                        .session(rootSession))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("공지사항 상태 변경 → 200")
+    void changeStatus() throws Exception {
+        String createBody = objectMapper.writeValueAsString(
+                Map.of("title", "상태변경 테스트", "content", "내용",
+                        "startsAt", "2026-04-04T00:00:00",
+                        "isServiceMaintenance", false));
+
+        MvcResult createResult = mockMvc.perform(post("/api/notice")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long noticeId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        String statusBody = objectMapper.writeValueAsString(
+                Map.of("status", "PUBLISHED"));
+
+        mockMvc.perform(patch("/api/notice/" + noticeId + "/status")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("공지사항 삭제 → 204")
+    void delete_notice() throws Exception {
+        String createBody = objectMapper.writeValueAsString(
+                Map.of("title", "삭제 테스트", "content", "내용",
+                        "startsAt", "2026-04-04T00:00:00",
+                        "isServiceMaintenance", false));
+
+        MvcResult createResult = mockMvc.perform(post("/api/notice")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long noticeId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        mockMvc.perform(delete("/api/notice/" + noticeId)
+                        .session(rootSession))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("미인증 접근 → 401")
+    void unauthenticated_access() throws Exception {
+        mockMvc.perform(get("/api/notice"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/_backoffice/backend/src/test/java/com/backoffice/sosangongin/permission/PermissionApiTest.java
+++ b/_backoffice/backend/src/test/java/com/backoffice/sosangongin/permission/PermissionApiTest.java
@@ -1,0 +1,96 @@
+package com.backoffice.sosangongin.permission;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PermissionApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpSession rootSession;
+
+    @BeforeEach
+    void login() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        rootSession = (MockHttpSession) result.getRequest().getSession();
+    }
+
+    @Test
+    @DisplayName("permission 생성 → 201")
+    void create_permission() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("permissionName", "test.create", "permDomain", "test"));
+
+        mockMvc.perform(post("/api/permission")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.permissionName").value("test.create"));
+    }
+
+    @Test
+    @DisplayName("permission 중복 생성 → 409")
+    void create_duplicate_permission() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("permissionName", "dup.test", "permDomain", "dup"));
+
+        mockMvc.perform(post("/api/permission")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/permission")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("permission 전체 조회 → 200")
+    void findAll_permissions() throws Exception {
+        mockMvc.perform(get("/api/permission")
+                        .session(rootSession))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("미인증 접근 → 401")
+    void unauthenticated_access() throws Exception {
+        mockMvc.perform(get("/api/permission"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/_backoffice/backend/src/test/java/com/backoffice/sosangongin/role/RoleApiTest.java
+++ b/_backoffice/backend/src/test/java/com/backoffice/sosangongin/role/RoleApiTest.java
@@ -1,0 +1,123 @@
+package com.backoffice.sosangongin.role;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class RoleApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpSession rootSession;
+
+    @BeforeEach
+    void login() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("loginId", "root", "password", "root"));
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        rootSession = (MockHttpSession) result.getRequest().getSession();
+    }
+
+    @Test
+    @DisplayName("role 생성 → 201")
+    void create_role() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("roleName", "test-editor", "description", "테스트 편집자"));
+
+        mockMvc.perform(post("/api/role")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.roleName").value("test-editor"));
+    }
+
+    @Test
+    @DisplayName("role 중복 생성 → 409")
+    void create_duplicate_role() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                Map.of("roleName", "dup-role", "description", "중복"));
+
+        mockMvc.perform(post("/api/role")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/role")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("role 전체 조회 → 200")
+    void findAll_roles() throws Exception {
+        mockMvc.perform(get("/api/role")
+                        .session(rootSession))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("role-permission 매핑 (존재하지 않는 permissionId) → 404")
+    void updatePermissions_notFound() throws Exception {
+        String createBody = objectMapper.writeValueAsString(
+                Map.of("roleName", "perm-test-role", "description", "매핑테스트"));
+
+        MvcResult createResult = mockMvc.perform(post("/api/role")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createBody))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        Long roleId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asLong();
+
+        String mappingBody = objectMapper.writeValueAsString(
+                Map.of("permissionIds", List.of(99999L)));
+
+        mockMvc.perform(put("/api/role/" + roleId + "/permissions")
+                        .session(rootSession)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mappingBody))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("미인증 접근 → 401")
+    void unauthenticated_access() throws Exception {
+        mockMvc.perform(get("/api/role"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## 개요
 - 브랜치 의존 구조로 인해 account, role-permission, notice 작업이 하나의 PR에 포함되었습니다.

## 포함된 작업
- 관리자 계정 CRUD
- 역할 및 권한 정의 (role/permission CRUD, 매핑)
- 공지사항 CRUD 및 상태 관리
- PermissionAspect 권한 체크 구현

Closes #21
Closes #23
Closes #25