### PR TITLE
[activity-log-front] 활동 이력 조회 화면 추가

### DIFF
--- a/_backoffice/frontend/app/(main)/backoffice/activity-log/audit/page.tsx
+++ b/_backoffice/frontend/app/(main)/backoffice/activity-log/audit/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { ListLayout, TableColumn } from '@/components';
+
+interface AuditLog {
+  id: number;
+  accountId: string;
+  actionType: string;
+  resourceDomain: string;
+  resourceId: string | null;
+  createdAt: string;
+}
+
+const MOCK_AUDIT_LOGS: AuditLog[] = [
+  {
+    id: 1,
+    accountId: '7331b320-06bd-4193-b675-96585cebd887',
+    actionType: 'CREATE',
+    resourceDomain: 'NOTICE',
+    resourceId: '1',
+    createdAt: '2026-04-05 22:31:24',
+  },
+  {
+    id: 2,
+    accountId: '7331b320-06bd-4193-b675-96585cebd887',
+    actionType: 'DELETE',
+    resourceDomain: 'NOTICE',
+    resourceId: '1',
+    createdAt: '2026-04-05 22:32:18',
+  },
+];
+
+export default function AuditLogPage() {
+  const [searchField, setSearchField] = useState('actionType');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+
+  const filtered = MOCK_AUDIT_LOGS.filter((log) => {
+    const value = log[searchField as keyof AuditLog]?.toString().toLowerCase() ?? '';
+    return value.includes(searchQuery.toLowerCase());
+  });
+
+  const totalPages = Math.ceil(filtered.length / itemsPerPage);
+  const currentItems = filtered.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
+
+  const columns: TableColumn<AuditLog>[] = [
+    { header: 'No', render: (log) => log.id, width: '60px' },
+    { header: '계정ID', render: (log) => log.accountId },
+    { header: '작업유형', render: (log) => log.actionType, width: '120px' },
+    { header: '도메인', render: (log) => log.resourceDomain, width: '120px' },
+    { header: '리소스ID', render: (log) => log.resourceId ?? '-', width: '100px' },
+    { header: '등록일', render: (log) => log.createdAt, width: '160px' },
+  ];
+
+  const searchOptions = [
+    { value: 'actionType', label: '작업유형' },
+    { value: 'resourceDomain', label: '도메인' },
+  ];
+
+  return (
+    <ListLayout
+      title="활동 이력"
+      search={{
+        field: searchField,
+        onFieldChange: (e) => { setSearchField(e.target.value); setCurrentPage(1); },
+        options: searchOptions,
+        query: searchQuery,
+        onQueryChange: (e) => { setSearchQuery(e.target.value); setCurrentPage(1); },
+      }}
+      table={{
+        columns,
+        data: currentItems,
+        rowKey: (log) => String(log.id),
+        emptyMessage: '활동 이력이 없습니다.',
+      }}
+      pagination={{ currentPage, totalPages, onPageChange: setCurrentPage }}
+    />
+  );
+}

--- a/_backoffice/frontend/app/(main)/backoffice/activity-log/login/page.tsx
+++ b/_backoffice/frontend/app/(main)/backoffice/activity-log/login/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { ListLayout, TableColumn, Badge } from '@/components';
+
+interface LoginHistory {
+  id: number;
+  accountId: string;
+  ipAddress: string;
+  userAgent: string;
+  success: boolean;
+  createdAt: string;
+}
+
+const MOCK_LOGIN_HISTORIES: LoginHistory[] = [
+  {
+    id: 1,
+    accountId: '7331b320-06bd-4193-b675-96585cebd887',
+    ipAddress: '0:0:0:0:0:0:0:1',
+    userAgent: 'PostmanRuntime/7.53.0',
+    success: true,
+    createdAt: '2026-04-05 22:31:08',
+  },
+  {
+    id: 2,
+    accountId: '7331b320-06bd-4193-b675-96585cebd887',
+    ipAddress: '0:0:0:0:0:0:0:1',
+    userAgent: 'PostmanRuntime/7.53.0',
+    success: false,
+    createdAt: '2026-04-05 22:33:16',
+  },
+];
+
+export default function LoginHistoryPage() {
+  const [searchField, setSearchField] = useState('accountId');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+
+  const filtered = MOCK_LOGIN_HISTORIES.filter((log) => {
+    const value = log[searchField as keyof LoginHistory]?.toString().toLowerCase() ?? '';
+    return value.includes(searchQuery.toLowerCase());
+  });
+
+  const totalPages = Math.ceil(filtered.length / itemsPerPage);
+  const currentItems = filtered.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
+
+  const columns: TableColumn<LoginHistory>[] = [
+    { header: 'No', render: (log) => log.id, width: '60px' },
+    { header: '계정ID', render: (log) => log.accountId },
+    { header: 'IP주소', render: (log) => log.ipAddress, width: '160px' },
+    { header: '브라우저', render: (log) => log.userAgent },
+    {
+      header: '결과',
+      render: (log) => (
+        <Badge variant={log.success ? 'success' : 'error'}>
+          {log.success ? '성공' : '실패'}
+        </Badge>
+      ),
+      width: '100px',
+    },
+    { header: '등록일', render: (log) => log.createdAt, width: '160px' },
+  ];
+
+  const searchOptions = [
+    { value: 'accountId', label: '계정ID' },
+    { value: 'success', label: '결과' },
+  ];
+
+  return (
+    <ListLayout
+      title="로그인 이력"
+      search={{
+        field: searchField,
+        onFieldChange: (e) => { setSearchField(e.target.value); setCurrentPage(1); },
+        options: searchOptions,
+        query: searchQuery,
+        onQueryChange: (e) => { setSearchQuery(e.target.value); setCurrentPage(1); },
+      }}
+      table={{
+        columns,
+        data: currentItems,
+        rowKey: (log) => String(log.id),
+        emptyMessage: '로그인 이력이 없습니다.',
+      }}
+      pagination={{ currentPage, totalPages, onPageChange: setCurrentPage }}
+    />
+  );
+}

--- a/_backoffice/frontend/app/(main)/backoffice/roles/page.tsx
+++ b/_backoffice/frontend/app/(main)/backoffice/roles/page.tsx
@@ -91,7 +91,7 @@ export default function RolesPage() {
 
   const columns: TableColumn<Role>[] = [
     { header: 'No', render: (r) => r.id, width: '60px' },
-    { header: '권한명', render: (r) => <strong>{r.name}</strong>, width: '130px' },
+    { header: '역할', render: (r) => <strong>{r.name}</strong>, width: '130px' },
     { header: '설명', render: (r) => r.description },
     {
       header: '권한 목록',
@@ -111,7 +111,8 @@ export default function RolesPage() {
     { header: '수정일', render: (r) => r.updatedAt ?? '-', width: '140px' },
   ];
 
-  const searchOptions = [{ value: 'name', label: '권한명' }];
+  const searchOptions = [{ value: 'name', label: '역할' },
+      { value: 'permission', label: '권한' },];
 
   return (
     <>

--- a/_backoffice/frontend/components/layout/Header/Header.tsx
+++ b/_backoffice/frontend/components/layout/Header/Header.tsx
@@ -20,6 +20,8 @@ const menuItems: NavigationItem[] = [
     label: '시스템 설정',
     subItems: [
       { label: '공지사항 관리', href: '/backoffice/notices' },
+      { label: '활동 이력', href: '/backoffice/activity-log/audit' },
+      { label: '로그인 이력', href: '/backoffice/activity-log/login' },
     ]
   }
 ];

--- a/_backoffice/frontend/components/molecules/Navbar/NavItem.module.css
+++ b/_backoffice/frontend/components/molecules/Navbar/NavItem.module.css
@@ -33,8 +33,9 @@
 
 .dropdown {
   position: absolute;
-  top: calc(100% + 10px);
+  top: calc(100%);
   left: 0;
+  padding-top: 10px;
   background-color: #1e293b;
   border: 1px solid rgba(255, 255, 255, 0.08);
   min-width: 180px;


### PR DESCRIPTION
## 개요
- 백엔드 activity-log API에 대응하는 프론트 이력 조회 화면 구현

## 작업 내용
- 로그인 이력 조회 페이지 (activity-log/login)
- 활동 이력 조회 페이지 (activity-log/audit)
- Header 메뉴에 활동 이력/로그인 이력 항목 추가

## 부수 작업
- NavItem 드롭다운 hover 끊김 수정 (top gap → padding으로 교체)
- roles 페이지 라벨 수정

## 현재 상태
- mock 데이터 기반, API 연동은 별도 브랜치에서 진행 예정