### PR TITLE
[integration-auth] 백오피스 인증 API 연동

### DIFF
--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.backoffice.sosangongin.auth.dto.LoginRequest;
 import com.backoffice.sosangongin.auth.dto.LoginResponse;
 import com.backoffice.sosangongin.auth.session.SessionManager;
 import com.backoffice.sosangongin.auth.usecase.LoginUseCase;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,8 +27,14 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout() {
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
         sessionManager.invalidate();
+
+        Cookie cookie = new Cookie("JSESSIONID", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
         return ResponseEntity.ok().build();
     }
 }

--- a/_backoffice/frontend/app/(auth)/login/page.tsx
+++ b/_backoffice/frontend/app/(auth)/login/page.tsx
@@ -3,51 +3,49 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, Input, Button, Container, Form } from '../../../components';
+import { api, ApiError } from '../../../lib/api';
 import styles from './login.module.css';
-
-// 최초 로그인 유저 시뮬레이션 (실제로는 API 응답으로 판단)
-const FIRST_TIME_USERS = ['newuser', 'test123'];
-
-const MAX_ATTEMPTS = 5;
 
 export default function LoginPage() {
   const [id, setId] = useState('');
   const [password, setPassword] = useState('');
-  const [failCount, setFailCount] = useState(0);
   const [errorMsg, setErrorMsg] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
-  const handleLogin = (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!id || !password) return;
 
-    if (FIRST_TIME_USERS.includes(id)) {
-      router.push('/login/change-password');
-      return;
-    }
+    setIsLoading(true);
+    setErrorMsg('');
 
-    // Demo: password '1234' → success, anything else → failure
-    if (password === '1234') {
-      setErrorMsg('');
-      router.push('/verify');
-      return;
-    }
+    try {
+      const response = await api.post<{
+        id: string;
+        name: string;
+        root: boolean;
+        passwordExpired: boolean;
+      }>('/api/auth/login', { loginId: id, password });
 
-    const newCount = failCount + 1;
-    setFailCount(newCount);
+      if (response.passwordExpired) {
+        router.push('/login/change-password');
+        return;
+      }
 
-    if (newCount >= MAX_ATTEMPTS) {
-      const now = Date.now();
-      const history = Array.from({ length: MAX_ATTEMPTS }, (_, i) => ({
-        attempt: i + 1,
-        time: new Date(now - (MAX_ATTEMPTS - 1 - i) * 4 * 60 * 1000).toISOString(),
-        ip: `192.168.1.${100 + i}`,
-      }));
-      sessionStorage.setItem('lockHistory', JSON.stringify({ id, history }));
-      router.push('/locked');
-    } else {
-      const remaining = MAX_ATTEMPTS - newCount;
-      setErrorMsg(`비밀번호가 올바르지 않습니다. (${newCount}/${MAX_ATTEMPTS}회 실패, ${remaining}회 남음)`);
+      router.push('/backoffice');
+    } catch (e) {
+      if (e instanceof ApiError) {
+        if (e.status === 403) {
+          router.push('/locked');
+        } else {
+          setErrorMsg(e.message);
+        }
+      } else {
+        setErrorMsg('오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -89,17 +87,9 @@ export default function LoginPage() {
           {errorMsg && (
             <p className={styles.errorMsg}>{errorMsg}</p>
           )}
-          {failCount > 0 && failCount < MAX_ATTEMPTS && (
-            <div className={styles.attemptsBar}>
-              {Array.from({ length: MAX_ATTEMPTS }, (_, i) => (
-                <div
-                  key={i}
-                  className={`${styles.attemptDot} ${i < failCount ? styles.attemptFailed : ''}`}
-                />
-              ))}
-            </div>
-          )}
-          <Button type="submit">로그인</Button>
+          <Button type="submit" disabled={isLoading}>
+            {isLoading ? '로그인 중...' : '로그인'}
+          </Button>
         </Form>
       </Card>
     </Container>

--- a/_backoffice/frontend/components/layout/Header/Header.tsx
+++ b/_backoffice/frontend/components/layout/Header/Header.tsx
@@ -7,6 +7,7 @@ import { Navbar } from '../../molecules/Navbar/Navbar';
 import { ConfirmModal } from '../../molecules/ConfirmModal/ConfirmModal';
 import styles from './Header.module.css';
 import {NavigationItem} from "@/types";
+import { api } from '../../../lib/api';
 
 const menuItems: NavigationItem[] = [
   {
@@ -35,9 +36,15 @@ export const Header: React.FC = () => {
     setIsModalOpen(true);
   };
 
-  const handleConfirmLogout = () => {
-    setIsModalOpen(false);
-    router.push('/login');
+  const handleConfirmLogout = async () => {
+    try {
+      await api.post('/api/auth/logout');
+    } catch (e) {
+      // 로그아웃 실패해도 로그인 페이지로 이동
+    } finally {
+      setIsModalOpen(false);
+      router.push('/login');
+    }
   };
 
   return (

--- a/_backoffice/frontend/lib/api.ts
+++ b/_backoffice/frontend/lib/api.ts
@@ -1,0 +1,48 @@
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
+
+export class ApiError extends Error {
+    status: number;
+
+constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+    this.name = 'ApiError';
+  }
+}
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${BASE_URL}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options?.headers,
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+
+    if (response.status === 401) {
+      if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+        window.location.href = '/login';
+      }
+    }
+
+    throw new ApiError(response.status, error.message ?? '오류가 발생했습니다.');
+  }
+
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'POST', body: JSON.stringify(body) }),
+  patch: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'PATCH', body: JSON.stringify(body) }),
+  delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
+  put: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'PUT', body: JSON.stringify(body) }),
+};

--- a/_backoffice/frontend/middleware.ts
+++ b/_backoffice/frontend/middleware.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  const isAuthPage = pathname.startsWith('/login') ||
+                     pathname.startsWith('/locked') ||
+                     pathname.startsWith('/verify');
+
+  const sessionCookie = request.cookies.get('JSESSIONID');
+
+  if (!isAuthPage && !sessionCookie) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  if (isAuthPage && sessionCookie) {
+    return NextResponse.redirect(new URL('/backoffice', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
+};


### PR DESCRIPTION
## 개요
- 로그인/로그아웃 mock을 실제 API 연동으로 교체

## 작업 내용
- lib/api.ts API 호출 공통 함수 추가
- middleware.ts 인증 가드 추가
- 로그인 페이지 mock 제거 → POST /api/auth/login 연동
- Header 로그아웃 mock 제거 → POST /api/auth/logout 연동
- 백엔드 logout에서 JSESSIONID 쿠키 명시적 삭제 추가

## 주요 사항
### API 공통 함수
 - baseURL, credentials, 에러 처리를 한 곳에서 관리합니다.
 - 401 발생 시 로그인 페이지로 자동 리다이렉트합니다.
   - (로그인 페이지 자체는 제외)

### 인증 가드
 - JSESSIONID 쿠키 존재 여부로 인증 상태를 판단합니다.
 - 미인증 사용자는 로그인 페이지로 리다이렉트됩니다.

### 쿠키 명시적 삭제
 - session.invalidate()만으로는 브라우저 쿠키가 삭제 안됨
   - 로그아웃 후에도 미들웨어가 인증된 사용자로 인식하는 문제 발생
     - 백엔드 응답에 Set-Cookie 헤더로 명시적으로 삭제

Closes: #32 