### PR TITLE
[integration-account] 계정 관리 API 연동 및 검증 보강

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -41,7 +41,11 @@
       "Bash(git ls-tree:*)",
       "Bash(git reset:*)",
       "Read(//mnt/c/public/sosanggongin/**)",
-      "Bash(./gradlew :_backoffice:backend:compileJava)"
+      "Bash(./gradlew :_backoffice:backend:compileJava)",
+      "Bash(gh issue:*)",
+      "Bash(git -C \"C:/public/sosanggongin/platform-backend\" status)",
+      "Bash(git -C \"C:/public/sosanggongin/platform-backend\" diff HEAD --stat)",
+      "Bash(git -C \"C:/public/sosanggongin/platform-backend\" grep -n \"validation\" _backoffice/backend/build.gradle)"
     ]
   }
 }

--- a/_backoffice/backend/build.gradle.kts
+++ b/_backoffice/backend/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/controller/AccountController.java
@@ -7,6 +7,7 @@ import com.backoffice.sosangongin.account.dto.PasswordChangeRequest;
 import com.backoffice.sosangongin.account.usecase.AccountUseCase;
 import com.backoffice.sosangongin.auth.session.SessionManager;
 import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,13 +24,19 @@ public class AccountController {
     private final SessionManager sessionManager;
 
     @PostMapping
-    public ResponseEntity<AccountResponse> create(@RequestBody AccountCreateRequest request) {
+    public ResponseEntity<AccountResponse> create(@Valid @RequestBody AccountCreateRequest request) {
         return ResponseEntity.status(201).body(accountUseCase.create(request));
     }
 
     @GetMapping
     public ResponseEntity<List<AccountResponse>> findAll() {
         return ResponseEntity.ok(accountUseCase.findAll());
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<AccountResponse> getMe() {
+        UUID accountId = sessionManager.getRequiredAccountId();
+        return ResponseEntity.ok(accountUseCase.findById(accountId));
     }
 
     @GetMapping("/{id}")
@@ -39,7 +46,7 @@ public class AccountController {
 
     @PatchMapping("/{id}")
     public ResponseEntity<AccountResponse> update(@PathVariable UUID id,
-                                                  @RequestBody AccountUpdateRequest request) {
+                                                  @Valid @RequestBody AccountUpdateRequest request) {
         return ResponseEntity.ok(accountUseCase.update(id, request));
     }
 
@@ -56,9 +63,8 @@ public class AccountController {
     }
 
     @PatchMapping("/me/password")
-    public ResponseEntity<Void> changePassword(@RequestBody PasswordChangeRequest request) {
-        UUID requesterId = sessionManager.getAccountId()
-                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
+    public ResponseEntity<Void> changePassword(@Valid @RequestBody PasswordChangeRequest request) {
+        UUID requesterId = sessionManager.getRequiredAccountId();
         accountUseCase.changePassword(requesterId, request);
         return ResponseEntity.ok().build();
     }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountCreateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountCreateRequest.java
@@ -1,13 +1,25 @@
 package com.backoffice.sosangongin.account.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class AccountCreateRequest {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
     private String loginId;
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     private String name;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @Size(max = 20, message = "전화번호는 20자 이내여야 합니다.")
     private String phoneNumber;
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountResponse.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountResponse.java
@@ -18,6 +18,7 @@ public class AccountResponse {
     private boolean isRoot;
     private boolean isLocked;
     private boolean isPasswordExpired;
+    private LocalDateTime lockedAt;
     private LocalDateTime createdAt;
 
     public static AccountResponse from(BackofficeAdmin admin) {
@@ -30,6 +31,7 @@ public class AccountResponse {
                 .isRoot(admin.isRoot())
                 .isLocked(admin.isLocked())
                 .isPasswordExpired(admin.isPasswordExpired())
+                .lockedAt(admin.getLockedAt())
                 .createdAt(admin.getCreatedAt())
                 .build();
     }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountUpdateRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/AccountUpdateRequest.java
@@ -1,12 +1,22 @@
 package com.backoffice.sosangongin.account.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class AccountUpdateRequest {
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    @Size(max = 50, message = "이름은 50자 이내여야 합니다.")
     private String name;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @Size(max = 20, message = "전화번호는 20자 이내여야 합니다.")
     private String phoneNumber;
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/PasswordChangeRequest.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/dto/PasswordChangeRequest.java
@@ -1,11 +1,16 @@
 package com.backoffice.sosangongin.account.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class PasswordChangeRequest {
+
+    @NotBlank(message = "현재 비밀번호를 입력해주세요.")
     private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호를 입력해주세요.")
     private String newPassword;
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/service/AccountService.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/account/service/AccountService.java
@@ -47,7 +47,7 @@ public class AccountService {
 
     @Transactional(readOnly = true)
     public BackofficeAdmin findById(UUID id) {
-        return adminRepository.findById(id)
+        return adminRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 계정입니다."));
     }
 

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/repos/AdminRepository.java
@@ -11,4 +11,5 @@ public interface AdminRepository extends JpaRepository<BackofficeAdmin, UUID> {
     Optional<BackofficeAdmin> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
     List<BackofficeAdmin> findByDeletedAtIsNull();
+    Optional<BackofficeAdmin> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/auth/session/SessionManager.java
@@ -1,5 +1,6 @@
 package com.backoffice.sosangongin.auth.session;
 
+import com.backoffice.sosangongin.global.exception.InvalidCredentialsException;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -34,6 +35,11 @@ public class SessionManager {
             return Optional.of(accountId);
         }
         return Optional.empty();
+    }
+
+    public UUID getRequiredAccountId() {
+        return getAccountId()
+                .orElseThrow(() -> new InvalidCredentialsException("인증 정보가 없습니다."));
     }
 
     public String getRole() {

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/account/me/password").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/account").authenticated()
                         .requestMatchers("/api/account/**").hasRole("ROOT")
                         .requestMatchers("/api/role/**").hasRole("ROOT")
                         .requestMatchers("/api/permission/**").hasRole("ROOT")

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/exception/GlobalExceptionHandler.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/exception/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import com.backoffice.sosangongin.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -33,6 +35,19 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleDuplicateResource(DuplicateResourceException e) {
         log.warn("[DuplicateResource] {}", e.getMessage());
         return buildResponse(HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler(ValidationFailedException.class)
+    public ResponseEntity<ErrorResponse> handleValidationFailed(ValidationFailedException e) {
+        log.warn("[ValidationFailed] {}", e.getMessage());
+        return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String message = fieldError != null ? fieldError.getDefaultMessage() : "요청 값이 올바르지 않습니다.";
+        return handleValidationFailed(new ValidationFailedException(message));
     }
 
     @ExceptionHandler(PermissionDeniedException.class)

--- a/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/exception/ValidationFailedException.java
+++ b/_backoffice/backend/src/main/java/com/backoffice/sosangongin/global/exception/ValidationFailedException.java
@@ -1,0 +1,8 @@
+package com.backoffice.sosangongin.global.exception;
+
+public class ValidationFailedException extends BackofficeBusinessError {
+
+    public ValidationFailedException(String message) {
+        super(message);
+    }
+}

--- a/_backoffice/frontend/app/(auth)/login/change-password/page.tsx
+++ b/_backoffice/frontend/app/(auth)/login/change-password/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, Button, Container, Form } from '../../../../components';
+import { api, ApiError } from '../../../../lib/api';
 import styles from './change-password.module.css';
 
 interface Requirements {
@@ -21,23 +22,36 @@ const allMet = (req: Requirements) => Object.values(req).every(Boolean);
 
 export default function ChangePasswordPage() {
   const router = useRouter();
+  const [currentPassword, setCurrentPassword] = useState('');
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
 
   const req = checkRequirements(password);
   const passwordsMatch = password === confirm;
   const confirmTouched = confirm.length > 0;
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitted(true);
     if (!allMet(req) || !passwordsMatch || !confirm) return;
 
-    // TODO: API 호출
-    router.push('/verify');
+    try {
+      await api.patch('/api/account/me/password', {
+        currentPassword,
+        newPassword: password,
+      });
+      router.push('/backoffice');
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setErrorMsg(e.message);
+      } else {
+        setErrorMsg('오류가 발생했습니다.');
+      }
+    }
   };
 
   const EyeIcon = ({ open }: { open: boolean }) => (
@@ -92,6 +106,28 @@ export default function ChangePasswordPage() {
         </div>
 
         <Form onSubmit={handleSubmit}>
+          <div className={styles.passwordWrapper}>
+            <input
+              id="current-password"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              placeholder="현재 비밀번호 (임시 비밀번호)"
+              style={{
+                width: '100%',
+                height: 38,
+                padding: '0 12px',
+                border: '1px solid #e2e8f0',
+                borderRadius: 6,
+                fontSize: 14,
+                marginBottom: 16,
+                boxSizing: 'border-box',
+                outline: 'none',
+                fontFamily: 'inherit',
+              }}
+            />
+          </div>
+
           <div className={styles.passwordWrapper}>
             <input
               id="new-password"
@@ -156,6 +192,10 @@ export default function ChangePasswordPage() {
             <p className={`${styles.matchMessage} ${passwordsMatch ? styles.matchOk : styles.matchFail}`}>
               {passwordsMatch ? '✓ 비밀번호가 일치합니다.' : '비밀번호가 일치하지 않습니다.'}
             </p>
+          )}
+
+          {errorMsg && (
+            <p style={{ color: '#ef4444', fontSize: 14, marginBottom: 8 }}>{errorMsg}</p>
           )}
 
           <Button type="submit" variant="success">

--- a/_backoffice/frontend/app/(main)/backoffice/users/[id]/page.tsx
+++ b/_backoffice/frontend/app/(main)/backoffice/users/[id]/page.tsx
@@ -5,21 +5,9 @@ import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import { User } from '@/types';
 import styles from './edit.module.css';
-import { Badge, Button, Card, DetailRow } from '@/components';
+import { Badge, Button, Card, DetailRow, Input } from '@/components';
 import { ConfirmModal } from '@/components/molecules/ConfirmModal/ConfirmModal';
-
-const ALL_USERS: User[] = [
-  { id: '1', name: '김관리', email: 'admin@example.com', roles: ['Admin'], joinDate: '2023-01-15', status: 'Active' },
-  { id: '2', name: '이매니저', email: 'manager@example.com', roles: ['Manager'], joinDate: '2023-03-22', status: 'Active' },
-  { id: '3', name: '박편집', email: 'editor1@example.com', roles: ['Editor'], joinDate: '2023-06-10', status: 'Inactive' },
-  { id: '4', name: '최수정', email: 'editor2@example.com', roles: ['Editor'], joinDate: '2023-08-05', status: 'Active' },
-  { id: '5', name: '정운영', email: 'op@example.com', roles: ['Manager'], joinDate: '2023-11-12', status: 'Active' },
-  { id: '6', name: '한보안', email: 'security@example.com', roles: ['Admin', 'Manager'], joinDate: '2024-01-20', status: 'Active' },
-  { id: '13', name: '오신입', email: 'new1@example.com', phone: '010-1234-5678', roles: ['Editor'], joinDate: '2024-03-20', status: 'Pending' },
-  { id: '14', name: '권대기', email: 'new2@example.com', phone: '010-9876-5432', roles: ['Manager'], joinDate: '2024-03-21', status: 'Pending' },
-  { id: '15', name: '류잠금', email: 'locked1@example.com', phone: '010-5555-1234', roles: ['Editor'], joinDate: '2024-01-08', status: 'Locked', lockedAt: '2024-03-24T14:32:00' },
-  { id: '16', name: '노보안', email: 'locked2@example.com', phone: '010-7777-9999', roles: ['Manager'], joinDate: '2023-11-05', status: 'Locked', lockedAt: '2024-03-25T09:15:00' },
-];
+import { api, ApiError } from '@/lib/api';
 
 export default function UserDetailPage() {
   const router = useRouter();
@@ -27,35 +15,76 @@ export default function UserDetailPage() {
   const userId = params.id as string;
 
   const [user, setUser] = useState<User | null>(null);
+  const [isRoot, setIsRoot] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editForm, setEditForm] = useState({ name: '', email: '', phoneNumber: '' });
   const [isUnlockModalOpen, setIsUnlockModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [unlockSuccess, setUnlockSuccess] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
 
   useEffect(() => {
-    const found = ALL_USERS.find((u) => u.id === userId);
-    if (found) setUser(found);
+    api.get<User>('/api/account/me')
+      .then((me) => {
+        if (!me.root) {
+          router.push('/backoffice/users');
+          return;
+        }
+        setIsRoot(true);
+        return api.get<User>(`/api/account/${userId}`);
+      })
+      .then((data) => {
+        if (!data) return;
+        setUser(data);
+        setEditForm({
+          name: data.name,
+          email: data.email ?? '',
+          phoneNumber: data.phoneNumber ?? '',
+        });
+      })
+      .catch(console.error);
   }, [userId]);
 
-  const handleUnlock = () => {
+  const handleUnlock = async () => {
     if (!user) return;
-    setUser({ ...user, status: 'Active', lockedAt: undefined });
-    setIsUnlockModalOpen(false);
-    setUnlockSuccess(true);
-    setTimeout(() => setUnlockSuccess(false), 3000);
+    try {
+      await api.patch(`/api/account/${userId}/unlock`);
+      setUser({ ...user, locked: false, lockedAt: null });
+      setIsUnlockModalOpen(false);
+      setUnlockSuccess(true);
+      setTimeout(() => setUnlockSuccess(false), 3000);
+    } catch (e) {
+      if (e instanceof ApiError) setErrorMsg(e.message);
+    }
   };
 
-  const formatDateTime = (iso?: string) => {
-    if (!iso) return '-';
-    return new Date(iso).toLocaleString('ko-KR', {
-      year: 'numeric', month: '2-digit', day: '2-digit',
-      hour: '2-digit', minute: '2-digit',
-    });
+  const handleSave = async () => {
+    if (!user) return;
+    try {
+      const updated = await api.patch<User>(`/api/account/${userId}`, {
+        name: editForm.name,
+        email: editForm.email || null,
+        phoneNumber: editForm.phoneNumber || null,
+      });
+      setUser(updated);
+      setIsEditing(false);
+    } catch (e) {
+      if (e instanceof ApiError) setErrorMsg(e.message);
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await api.delete(`/api/account/${userId}`);
+      router.push('/backoffice/users');
+    } catch (e) {
+      if (e instanceof ApiError) setErrorMsg(e.message);
+    }
   };
 
   if (!user) {
-    return <div className={styles.container}>사용자를 찾을 수 없습니다.</div>;
+    return <div className={styles.container}>로딩 중...</div>;
   }
-
-  const isLocked = user.status === 'Locked';
 
   return (
     <div className={styles.container}>
@@ -67,62 +96,103 @@ export default function UserDetailPage() {
 
       {unlockSuccess && (
         <div className={styles.successBanner}>
-          계정 잠금이 해제되었습니다. 사용자가 다시 로그인할 수 있습니다.
+          계정 잠금이 해제되었습니다.
         </div>
+      )}
+
+      {errorMsg && (
+        <div className={styles.errorBanner}>{errorMsg}</div>
       )}
 
       <Card className={styles.formCard}>
         <div className={styles.cardHeader}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <h2 className={styles.cardTitle}>사용자 상세 정보</h2>
-            {isLocked && (
-              <Button variant="danger" style={{ width: 'auto', padding: '0 16px', height: 36 }} onClick={() => setIsUnlockModalOpen(true)}>
-                잠금 해제
-              </Button>
+            {isRoot && (
+              <div style={{ display: 'flex', gap: '8px' }}>
+                {user.locked && (
+                  <Button variant="danger" style={{ width: 'auto', padding: '0 16px', height: 36 }}
+                    onClick={() => setIsUnlockModalOpen(true)}>
+                    잠금 해제
+                  </Button>
+                )}
+                {!isEditing ? (
+                  <>
+                    <Button style={{ width: 'auto', padding: '0 16px', height: 36 }}
+                      onClick={() => setIsEditing(true)}>
+                      수정
+                    </Button>
+                    <Button variant="danger" style={{ width: 'auto', padding: '0 16px', height: 36 }}
+                      onClick={() => setIsDeleteModalOpen(true)}>
+                      삭제
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button variant="success" style={{ width: 'auto', padding: '0 16px', height: 36 }}
+                      onClick={handleSave}>
+                      저장
+                    </Button>
+                    <Button variant="secondary" style={{ width: 'auto', padding: '0 16px', height: 36 }}
+                      onClick={() => setIsEditing(false)}>
+                      취소
+                    </Button>
+                  </>
+                )}
+              </div>
             )}
           </div>
         </div>
 
         <div className={styles.cardBody}>
-          <DetailRow label="사용자 ID">{user.id}</DetailRow>
-          <DetailRow label="이름">{user.name}</DetailRow>
-          <DetailRow label="이메일 주소">{user.email}</DetailRow>
-          {user.phone && <DetailRow label="전화번호">{user.phone}</DetailRow>}
-          <DetailRow label="접근 권한">
-            <span style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-              {user.roles.map((r) => (
-                <Badge key={r} variant="info">{r}</Badge>
-              ))}
-            </span>
+          <DetailRow label="UUID">{user.id}</DetailRow>
+          <DetailRow label="아이디">{user.loginId}</DetailRow>
+          <DetailRow label="이름">
+            {isEditing ? (
+              <Input id="edit-name" value={editForm.name}
+                onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                wrapperStyle={{ marginBottom: 0, maxWidth: 400 }} />
+            ) : user.name}
+          </DetailRow>
+          <DetailRow label="이메일">
+            {isEditing ? (
+              <Input id="edit-email" value={editForm.email}
+                onChange={(e) => setEditForm({ ...editForm, email: e.target.value })}
+                placeholder="이메일 (선택)"
+                wrapperStyle={{ marginBottom: 0, maxWidth: 400 }} />
+            ) : user.email ?? '-'}
+          </DetailRow>
+          <DetailRow label="전화번호">
+            {isEditing ? (
+              <Input id="edit-phone" value={editForm.phoneNumber}
+                onChange={(e) => setEditForm({ ...editForm, phoneNumber: e.target.value })}
+                placeholder="전화번호 (선택)"
+                wrapperStyle={{ marginBottom: 0, maxWidth: 400 }} />
+            ) : user.phoneNumber ?? '-'}
           </DetailRow>
           <DetailRow label="계정 상태">
             <span style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-              {user.status === 'Active' && <Badge variant="success">활성</Badge>}
-              {user.status === 'Inactive' && <Badge variant="error">비활성</Badge>}
-              {user.status === 'Pending' && <Badge variant="warning">대기중</Badge>}
-              {user.status === 'Locked' && <Badge variant="error">잠금</Badge>}
-              {isLocked && (
-                <span className={styles.lockReason}>
-                  비밀번호 5회 오류로 잠금됨
-                </span>
+              {user.locked && <Badge variant="error">잠금</Badge>}
+              {!user.locked && user.passwordExpired && <Badge variant="warning">임시 비밀번호</Badge>}
+              {!user.locked && !user.passwordExpired && <Badge variant="success">활성</Badge>}
+              {user.locked && (
+                <span className={styles.lockReason}>비밀번호 5회 오류로 잠금됨</span>
               )}
             </span>
           </DetailRow>
-          {isLocked && user.lockedAt && (
-            <DetailRow label="잠금 시각">{formatDateTime(user.lockedAt)}</DetailRow>
+          {user.lockedAt && (
+            <DetailRow label="잠금 시각">{new Date(user.lockedAt).toLocaleString('ko-KR')}</DetailRow>
           )}
-          <DetailRow label="가입일">{user.joinDate}</DetailRow>
+          <DetailRow label="등록일">{user.createdAt}</DetailRow>
 
-          <div className={styles.footer}>
-            <Button
-              type="button"
-              variant="secondary"
-              style={{ width: 130 }}
-              onClick={() => router.push('/backoffice/users')}
-            >
-              목록으로 돌아가기
-            </Button>
-          </div>
+          {!isEditing && (
+            <div className={styles.footer}>
+              <Button variant="secondary" style={{ width: 130 }}
+                onClick={() => router.push('/backoffice/users')}>
+                목록으로 돌아가기
+              </Button>
+            </div>
+          )}
         </div>
       </Card>
 
@@ -133,9 +203,18 @@ export default function UserDetailPage() {
         title="계정 잠금 해제"
       >
         <strong>{user.name}</strong> 님의 계정 잠금을 해제하시겠습니까?
+      </ConfirmModal>
+
+      <ConfirmModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={handleDelete}
+        title="계정 삭제"
+      >
+        <strong>{user.name}</strong> 님의 계정을 삭제하시겠습니까?
         <br />
         <span style={{ color: '#64748b', fontSize: '0.875rem' }}>
-          잠금 해제 후 사용자는 즉시 로그인이 가능합니다.
+          삭제된 계정은 목록에서 숨겨집니다.
         </span>
       </ConfirmModal>
     </div>

--- a/_backoffice/frontend/app/(main)/backoffice/users/new/page.tsx
+++ b/_backoffice/frontend/app/(main)/backoffice/users/new/page.tsx
@@ -4,54 +4,90 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Card, Input, Button, DetailRow } from '@/components';
+import { api, ApiError } from '@/lib/api';
 import styles from './new.module.css';
-// TODO :: 새로운 유저가 등록되면, 등록된 유저의 전화번호로 id와 초기비밀번호, URL을 함께 전송
-// 시스템에 등록된 권한 목록 (실제로는 API에서 가져옴)
-const AVAILABLE_ROLES = ['Admin', 'Manager', 'Editor'];
 
 interface FormState {
   name: string;
-  id: string;
-  phone: string;
-  roles: string[];
+  loginId: string;
+  email: string;
+  phoneNumber: string;
 }
 
-const emptyForm: FormState = { name: '', id: '', phone: '', roles: [] };
+const emptyForm: FormState = { name: '', loginId: '', email: '', phoneNumber: '' };
 
 export default function NewUserPage() {
   const router = useRouter();
   const [form, setForm] = useState<FormState>(emptyForm);
   const [submitted, setSubmitted] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+  const [createdLoginId, setCreatedLoginId] = useState<string | null>(null);
 
   const set = (patch: Partial<FormState>) => setForm((prev) => ({ ...prev, ...patch }));
 
-  const toggleRole = (role: string) => {
-    set({
-      roles: form.roles.includes(role)
-        ? form.roles.filter((r) => r !== role)
-        : [...form.roles, role],
-    });
-  };
-
   const validate = () => {
     if (!form.name.trim()) return false;
-    if (!form.id.trim()) return false;
-    if (!form.phone.trim()) return false;
-    if (form.roles.length === 0) return false;
+    if (!form.loginId.trim()) return false;
     return true;
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     setSubmitted(true);
     if (!validate()) return;
 
-    // TODO: API 호출
-    alert(`유저 등록 완료\n이름: ${form.name}\nID: ${form.id}\n전화번호: ${form.phone}\n권한: ${form.roles.join(', ')}`);
-    router.push('/backoffice/users');
+    try {
+      await api.post('/api/account', {
+        name: form.name,
+        loginId: form.loginId,
+        email: form.email || null,
+        phoneNumber: form.phoneNumber || null,
+      });
+      setCreatedLoginId(form.loginId);
+    } catch (e) {
+      if (e instanceof ApiError) {
+        setErrorMsg(e.message);
+      } else {
+        setErrorMsg('오류가 발생했습니다.');
+      }
+    }
   };
 
   const fieldError = (value: string) => submitted && !value.trim();
-  const rolesError = submitted && form.roles.length === 0;
+
+  if (createdLoginId) {
+    return (
+      <div className={styles.container}>
+        <Card className={styles.formCard}>
+          <div className={styles.cardHeader}>
+            <h2 className={styles.cardTitle}>등록 완료</h2>
+          </div>
+          <div className={styles.cardBody}>
+            <p style={{ marginBottom: 16, color: '#334155' }}>
+              새 관리자 계정이 등록되었습니다.
+            </p>
+            <div style={{ background: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: 6, padding: '12px 16px', marginBottom: 24 }}>
+              <p style={{ fontSize: 14, color: '#64748b', marginBottom: 8 }}>초기 로그인 정보</p>
+              <p style={{ fontSize: 14, color: '#334155' }}>아이디: <strong>{createdLoginId}</strong></p>
+              <p style={{ fontSize: 14, color: '#334155' }}>초기 비밀번호: <strong>{createdLoginId}</strong></p>
+              <p style={{ fontSize: 12, color: '#94a3b8', marginTop: 8 }}>
+                첫 로그인 시 비밀번호 변경이 필요합니다.
+              </p>
+            </div>
+            <div className={styles.footer}>
+              <Button variant="secondary" style={{ width: 130 }}
+                onClick={() => router.push('/backoffice/users')}>
+                목록으로
+              </Button>
+              <Button style={{ width: 160 }}
+                onClick={() => { setCreatedLoginId(null); setForm(emptyForm); setSubmitted(false); }}>
+                추가 등록
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.container}>
@@ -82,50 +118,42 @@ export default function NewUserPage() {
 
           <DetailRow label="아이디">
             <Input
-              id="user-id"
-              value={form.id}
-              onChange={(e) => set({ id: e.target.value })}
+              id="user-loginId"
+              value={form.loginId}
+              onChange={(e) => set({ loginId: e.target.value })}
               placeholder="로그인에 사용할 아이디를 입력하세요"
               wrapperStyle={{ marginBottom: 0, maxWidth: 400 }}
             />
-            {fieldError(form.id) && (
+            {fieldError(form.loginId) && (
               <span className={styles.errorMessage}>아이디를 입력해주세요.</span>
             )}
+          </DetailRow>
+
+          <DetailRow label="이메일">
+            <Input
+              id="user-email"
+              type="email"
+              value={form.email}
+              onChange={(e) => set({ email: e.target.value })}
+              placeholder="이메일을 입력하세요 (선택)"
+              wrapperStyle={{ marginBottom: 0, maxWidth: 400 }}
+            />
           </DetailRow>
 
           <DetailRow label="전화번호">
             <Input
               id="user-phone"
               type="tel"
-              value={form.phone}
-              onChange={(e) => set({ phone: e.target.value })}
-              placeholder="010-0000-0000"
+              value={form.phoneNumber}
+              onChange={(e) => set({ phoneNumber: e.target.value })}
+              placeholder="010-0000-0000 (선택)"
               wrapperStyle={{ marginBottom: 0, maxWidth: 400 }}
             />
-            {fieldError(form.phone) && (
-              <span className={styles.errorMessage}>전화번호를 입력해주세요.</span>
-            )}
           </DetailRow>
 
-          <DetailRow label="권한">
-            <div>
-              <div className={styles.rolesGroup}>
-                {AVAILABLE_ROLES.map((role) => (
-                  <label key={role} className={styles.roleCheckLabel}>
-                    <input
-                      type="checkbox"
-                      checked={form.roles.includes(role)}
-                      onChange={() => toggleRole(role)}
-                    />
-                    {role}
-                  </label>
-                ))}
-              </div>
-              {rolesError && (
-                <p className={styles.errorMessage}>권한을 하나 이상 선택해주세요.</p>
-              )}
-            </div>
-          </DetailRow>
+          {errorMsg && (
+            <p className={styles.errorMessage}>{errorMsg}</p>
+          )}
 
           <div className={styles.footer}>
             <Button

--- a/_backoffice/frontend/app/(main)/backoffice/users/page.tsx
+++ b/_backoffice/frontend/app/(main)/backoffice/users/page.tsx
@@ -1,74 +1,59 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import {Badge, Button, ListLayout, TableColumn} from "@/components";
-import {User} from "@/types";
+import { Badge, Button, ListLayout, TableColumn } from '@/components';
+import { User } from '@/types';
+import { api } from '@/lib/api';
 
-const ALL_USERS: User[] = [
-  { id: '1', name: '김관리', email: 'admin@example.com', roles: ['Admin'], joinDate: '2023-01-15', status: 'Active' },
-  { id: '2', name: '이매니저', email: 'manager@example.com', roles: ['Manager'], joinDate: '2023-03-22', status: 'Active' },
-  { id: '3', name: '박편집', email: 'editor1@example.com', roles: ['Editor'], joinDate: '2023-06-10', status: 'Inactive' },
-  { id: '4', name: '최수정', email: 'editor2@example.com', roles: ['Editor'], joinDate: '2023-08-05', status: 'Active' },
-  { id: '5', name: '정운영', email: 'op@example.com', roles: ['Manager'], joinDate: '2023-11-12', status: 'Active' },
-  { id: '6', name: '한보안', email: 'security@example.com', roles: ['Admin', 'Manager'], joinDate: '2024-01-20', status: 'Active' },
-  { id: '7', name: '강개발', email: 'dev1@example.com', roles: ['Editor'], joinDate: '2024-02-10', status: 'Active' },
-  { id: '8', name: '조디자인', email: 'design1@example.com', roles: ['Editor'], joinDate: '2024-02-15', status: 'Active' },
-  { id: '9', name: '윤기획', email: 'plan1@example.com', roles: ['Manager'], joinDate: '2024-02-20', status: 'Inactive' },
-  { id: '10', name: '임테스트', email: 'test1@example.com', roles: ['Editor'], joinDate: '2024-03-01', status: 'Active' },
-  { id: '11', name: '성지원', email: 'support1@example.com', roles: ['Manager'], joinDate: '2024-03-05', status: 'Active' },
-  { id: '12', name: '배로그', email: 'log1@example.com', roles: ['Editor'], joinDate: '2024-03-10', status: 'Active' },
-  { id: '13', name: '오신입', email: 'new1@example.com', phone: '010-1234-5678', roles: ['Editor'], joinDate: '2024-03-20', status: 'Pending' },
-  { id: '14', name: '권대기', email: 'new2@example.com', phone: '010-9876-5432', roles: ['Manager'], joinDate: '2024-03-21', status: 'Pending' },
-  { id: '15', name: '류잠금', email: 'locked1@example.com', phone: '010-5555-1234', roles: ['Editor'], joinDate: '2024-01-08', status: 'Locked', lockedAt: '2024-03-24T14:32:00' },
-  { id: '16', name: '노보안', email: 'locked2@example.com', phone: '010-7777-9999', roles: ['Manager'], joinDate: '2023-11-05', status: 'Locked', lockedAt: '2024-03-25T09:15:00' },
-];
+const getStatus = (user: User) => {
+  if (user.locked) return { label: '잠금', variant: 'error' as const };
+  if (user.passwordExpired) return { label: '대기중', variant: 'warning' as const };
+  return { label: '활성', variant: 'success' as const };
+};
 
 export default function UserManagementPage() {
   const router = useRouter();
+  const [users, setUsers] = useState<User[]>([]);
   const [searchField, setSearchField] = useState('name');
   const [searchQuery, setSearchQuery] = useState('');
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 5;
+  const itemsPerPage = 10;
 
-  const filteredUsers = ALL_USERS.filter((user) => {
-    const value = user[searchField as keyof User]?.toString().toLowerCase() || '';
+  useEffect(() => {
+    api.get<User[]>('/api/account').then(setUsers).catch(console.error);
+  }, []);
+
+  const filtered = users.filter((user) => {
+    const value = user[searchField as keyof User]?.toString().toLowerCase() ?? '';
     return value.includes(searchQuery.toLowerCase());
   });
 
-  const totalPages = Math.ceil(filteredUsers.length / itemsPerPage);
-  const currentItems = filteredUsers.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+  const totalPages = Math.ceil(filtered.length / itemsPerPage);
+  const currentItems = filtered.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage,
+  );
 
   const columns: TableColumn<User>[] = [
-    { header: 'ID', render: (user) => user.id, width: '80px' },
+    { header: '아이디', render: (user) => user.loginId, width: '120px' },
     { header: '이름', render: (user) => user.name },
-    { header: '이메일', render: (user) => user.email },
-    {
-      header: '권한',
-      render: (user) => (
-        <span style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
-          {user.roles.map((r) => (
-            <Badge key={r} variant="info">{r}</Badge>
-          ))}
-        </span>
-      ),
-    },
-    { header: '가입일', render: (user) => user.joinDate },
+    { header: '이메일', render: (user) => user.email ?? '-' },
     {
       header: '상태',
       render: (user) => {
-        if (user.status === 'Active') return <Badge variant="success">활성</Badge>;
-        if (user.status === 'Inactive') return <Badge variant="error">비활성</Badge>;
-        if (user.status === 'Locked') return <Badge variant="error">잠금</Badge>;
-        return <Badge variant="warning">대기중</Badge>;
+        const status = getStatus(user);
+        return <Badge variant={status.variant}>{status.label}</Badge>;
       },
+      width: '120px',
     },
+    { header: '등록일', render: (user) => user.createdAt, width: '160px' },
   ];
 
   const searchOptions = [
     { value: 'name', label: '이름' },
+    { value: 'loginId', label: '아이디' },
     { value: 'email', label: '이메일' },
-    { value: 'id', label: 'ID' },
   ];
 
   return (
@@ -85,7 +70,7 @@ export default function UserManagementPage() {
         columns,
         data: currentItems,
         rowKey: (user) => user.id,
-        emptyMessage: '검색 결과가 없습니다.',
+        emptyMessage: '등록된 사용자가 없습니다.',
         onRowClick: (user) => router.push(`/backoffice/users/${user.id}`),
       }}
       pagination={{ currentPage, totalPages, onPageChange: setCurrentPage }}

--- a/_backoffice/frontend/middleware.ts
+++ b/_backoffice/frontend/middleware.ts
@@ -3,9 +3,10 @@ import { NextRequest, NextResponse } from 'next/server';
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  const isAuthPage = pathname.startsWith('/login') ||
-                     pathname.startsWith('/locked') ||
-                     pathname.startsWith('/verify');
+  const isAuthPage = (pathname.startsWith('/login') &&
+                   !pathname.startsWith('/login/change-password')) ||
+                   pathname.startsWith('/locked') ||
+                   pathname.startsWith('/verify');
 
   const sessionCookie = request.cookies.get('JSESSIONID');
 

--- a/_backoffice/frontend/types/index.ts
+++ b/_backoffice/frontend/types/index.ts
@@ -6,13 +6,15 @@ export interface NavigationItem {
 
 export interface User {
   id: string;
+  loginId: string;
   name: string;
-  email: string;
-  phone?: string;
-  roles: string[];
-  joinDate: string;
-  status: 'Active' | 'Inactive' | 'Pending' | 'Locked';
-  lockedAt?: string;
+  email: string | null;
+  phoneNumber: string | null;
+  root: boolean;
+  locked: boolean;
+  passwordExpired: boolean;
+  lockedAt: string | null;
+  createdAt: string;
 }
 
 export interface RolePermission {
@@ -29,21 +31,18 @@ export interface Role {
   updatedAt?: string;
 }
 
-export type NoticeStatus = 'published' | 'draft' | 'scheduled';
+export type NoticeStatus = 'DRAFT' | 'PUBLISHED' | 'HIDDEN';
 
 export interface Notice {
-  id: string;
+  id: number;
   title: string;
   content: string;
-  isSystemMaintenance: boolean;
+  isServiceMaintenance: boolean;
   status: NoticeStatus;
-  startAt?: string;
-  endAt?: string;
-  scheduledAt?: string;
-  publishedAt?: string;
-  maintenanceStartAt?: string;
-  maintenanceEndAt?: string;
-  author: string;
+  startsAt?: string;
+  endsAt?: string;
+  authorName: string;
+  createdBy: string;
+  viewCount: number | null;
   createdAt: string;
-  updatedAt?: string;
 }


### PR DESCRIPTION
## 개요
 - 계정 관리 화면 mock을 실제 API 연동으로 교체합니다.

## 작업 내용
### 프론트엔드
 - 계정 목록/상세/등록/수정/삭제/잠금해제 API 연동
 - 첫 로그인 시 비밀번호 변경 페이지 연동
 - Notice 타입 정의를 백엔드 스펙에 맞춰 정리

### 백엔드
 - AccountResponse에 lockedAt 필드 추가
 - AccountService.findById soft-delete 적용
 - GET /api/account/me 추가
 - SecurityConfig GET /api/account(목록)과 비밀번호 변경은 인증된 사용자 허용, 나머지 /api/account/** ROOT 전용
 - AccountCreate/Update/PasswordChange DTO에 Bean Validation 적용
 - ValidationFailedException 추가, GlobalExceptionHandler에서 400응답 처리
 - spring-boot-starter-validation 의존성 추가

##  연관 이슈
closes #34 